### PR TITLE
docs: expand yacht info extraction and validate URL input

### DIFF
--- a/app_yacht/extraccion_datos_yate.md
+++ b/app_yacht/extraccion_datos_yate.md
@@ -1,0 +1,24 @@
+# Flujo de extracción de datos de yate y renderizado con `default-template`
+
+Este documento describe paso a paso cómo la aplicación obtiene la información de un yate a partir de una URL y la muestra mediante la plantilla por defecto. El proceso cubre desde la captura de la URL en la interfaz hasta la inserción del HTML final en el frontend.
+
+## 1. Captura de la URL y disparo del evento
+- El formulario del módulo de cálculo incluye un campo específico para la URL del yate (`#yachtUrl`) y el botón **Create Template** (`#createTemplateButton`). Este campo utiliza `type="url"` y valida que la dirección comience con `http` o `https`【F:app_yacht/modules/calc/calculator.php†L172-L176】.
+- `template.js` habilita o deshabilita el botón en función de una expresión regular que exige el protocolo y añade un listener para ejecutar `templateManager.createTemplate()` al pulsarlo【F:app_yacht/modules/template/js/template.js†L270-L276】【F:app_yacht/modules/template/js/template.js†L385-L387】.
+
+## 2. Recolección y envío de datos desde el frontend
+- `TemplateManager.collectFormData()` reúne los campos del formulario y añade la URL del yate al objeto `FormData`【F:app_yacht/shared/js/classes/TemplateManager.js†L52-L65】.
+- `TemplateManager.createTemplate()` valida la información y realiza una petición `fetch` `POST` a la URL AJAX definida, enviando el `FormData` construido【F:app_yacht/shared/js/classes/TemplateManager.js†L212-L260】.
+
+## 3. Procesamiento en el backend y scraping de la información del yate
+- `AppYachtBootstrap::handleCreateTemplate()` atiende la solicitud AJAX: obtiene el servicio de renderizado, recupera la URL del yate de `$_POST` y delega la extracción de datos al módulo `YachtInfoService`【F:app_yacht/core/bootstrap.php†L187-L201】.
+- `YachtInfoService::extractYachtInfo()` valida la URL, verifica dominios permitidos, aplica caché y realiza el scraping para retornar un arreglo con los datos principales del yate【F:app_yacht/modules/yachtinfo/yacht-info-service.php†L36-L70】.
+
+## 4. Preparación de datos y renderizado de la plantilla
+- `RenderEngine::createTemplate()` combina los datos del formulario con la información del yate recibida para generar el contenido HTML y de texto de la plantilla seleccionada【F:app_yacht/modules/render/render-engine.php†L128-L160】.
+- `default-template.php` utiliza `buildYachtInfoArray()` para estructurar la información del yate y luego imprime campos como eslora, tipo, constructor, año, tripulación, cabinas y huéspedes【F:app_yacht/modules/template/templates/default-template.php†L29-L72】【F:app_yacht/modules/template/templates/default-template.php†L136-L138】.
+
+## 5. Inserción del HTML en el frontend
+- Tras recibir la respuesta JSON exitosa, `TemplateManager.createTemplate()` reemplaza el contenido del contenedor `#result` con el HTML generado, mostrando la plantilla con los datos del yate en pantalla【F:app_yacht/shared/js/classes/TemplateManager.js†L266-L270】.
+
+Este flujo asegura que, al ingresar una URL válida y presionar **Create Template**, la aplicación extrae la información del yate, la combina con los cálculos y la muestra mediante la plantilla por defecto en el frontend.

--- a/app_yacht/extraccion_datos_yate.md
+++ b/app_yacht/extraccion_datos_yate.md
@@ -16,7 +16,7 @@ Este documento describe paso a paso cómo la aplicación obtiene la información
 
 ## 4. Preparación de datos y renderizado de la plantilla
 - `RenderEngine::createTemplate()` combina los datos del formulario con la información del yate y genera el contenido HTML y de texto de la plantilla seleccionada【F:app_yacht/modules/render/render-engine.php†L128-L160】.
-- `default-template.php` utiliza `buildYachtInfoArray()` para estructurar la información del yate y luego imprime campos como eslora, tipo, constructor, año, tripulación, cabinas y huéspedes【F:app_yacht/modules/template/templates/default-template.php†L29-L72】【F:app_yacht/modules/template/templates/default-template.php†L136-L138】.
+- `default-template.php` utiliza `buildYachtInfoArray()` y `buildCalcSnippetArray()` para estructurar la información del yate y los resultados de cálculo antes de imprimir campos como eslora, tipo, constructor, año, tripulación, cabinas y huéspedes【F:app_yacht/modules/template/templates/default-template.php†L29-L35】【F:app_yacht/modules/template/templates/default-template.php†L54-L138】.
 
 ## 5. Inserción del HTML en el frontend
 - Tras recibir la respuesta, `TemplateManager.createTemplate()` reemplaza el contenido del contenedor `#result` con el HTML generado, mostrando la plantilla con los datos del yate en pantalla【F:app_yacht/shared/js/classes/TemplateManager.js†L266-L270】.

--- a/app_yacht/extraccion_datos_yate.md
+++ b/app_yacht/extraccion_datos_yate.md
@@ -3,8 +3,8 @@
 Este documento describe paso a paso cómo la aplicación obtiene la información de un yate a partir de una URL y la muestra mediante la plantilla por defecto. El proceso cubre desde la captura de la URL en la interfaz hasta la inserción del HTML final en el frontend.
 
 ## 1. Captura de la URL y disparo del evento
-- El formulario del módulo de cálculo incluye un campo específico para la URL del yate (`#yachtUrl`) y el botón **Create Template** (`#createTemplateButton`). Este campo utiliza `type="url"` y valida que la dirección comience con `http` o `https`【F:app_yacht/modules/calc/calculator.php†L172-L176】.
-- `template.js` habilita o deshabilita el botón en función de una expresión regular que exige el protocolo y añade un listener para ejecutar `templateManager.createTemplate()` al pulsarlo【F:app_yacht/modules/template/js/template.js†L270-L276】【F:app_yacht/modules/template/js/template.js†L385-L387】.
+- El formulario del módulo de cálculo incluye un campo específico para la URL del yate (`#yachtUrl`) y el botón **Create Template** (`#createTemplateButton`). El campo está definido como `type="url"` con un `pattern` que obliga a iniciar con `http` o `https`, evitando entradas sin protocolo【F:app_yacht/modules/calc/calculator.php†L172-L176】.
+- `template.js` valida esa entrada en tiempo real: habilita o deshabilita el botón según una expresión regular con protocolo y registra un listener para invocar `templateManager.createTemplate()` al hacer clic【F:app_yacht/modules/template/js/template.js†L270-L276】【F:app_yacht/modules/template/js/template.js†L385-L387】.
 
 ## 2. Recolección y envío de datos desde el frontend
 - `TemplateManager.collectFormData()` reúne los campos del formulario y añade la URL del yate al objeto `FormData`【F:app_yacht/shared/js/classes/TemplateManager.js†L52-L65】.
@@ -12,7 +12,7 @@ Este documento describe paso a paso cómo la aplicación obtiene la información
 
 ## 3. Procesamiento en el backend y scraping de la información del yate
 - `AppYachtBootstrap::handleCreateTemplate()` atiende la solicitud AJAX: obtiene el servicio de renderizado, recupera la URL del yate de `$_POST` y delega la extracción de datos al módulo `YachtInfoService`【F:app_yacht/core/bootstrap.php†L187-L201】.
-- `YachtInfoService::extractYachtInfo()` valida la URL, verifica dominios permitidos, aplica caché y realiza el scraping para retornar un arreglo con los datos principales del yate【F:app_yacht/modules/yachtinfo/yacht-info-service.php†L36-L70】.
+- `YachtInfoService::extractYachtInfo()` valida la URL, comprueba dominios permitidos, utiliza caché y ejecuta el scraping para devolver un arreglo con los datos principales del yate【F:app_yacht/modules/yachtinfo/yacht-info-service.php†L36-L70】.
 
 ## 4. Preparación de datos y renderizado de la plantilla
 - `RenderEngine::createTemplate()` combina los datos del formulario con la información del yate recibida para generar el contenido HTML y de texto de la plantilla seleccionada【F:app_yacht/modules/render/render-engine.php†L128-L160】.

--- a/app_yacht/extraccion_datos_yate.md
+++ b/app_yacht/extraccion_datos_yate.md
@@ -1,24 +1,25 @@
 # Flujo de extracción de datos de yate y renderizado con `default-template`
 
-Este documento describe paso a paso cómo la aplicación obtiene la información de un yate a partir de una URL y la muestra mediante la plantilla por defecto. El proceso cubre desde la captura de la URL en la interfaz hasta la inserción del HTML final en el frontend.
+Este documento describe paso a paso cómo la aplicación obtiene la información de un yate a partir de una URL y la muestra mediante la plantilla por defecto. El proceso abarca desde la captura de la URL en la interfaz hasta la inserción del HTML final en el frontend.
 
 ## 1. Captura de la URL y disparo del evento
-- El formulario del módulo de cálculo incluye un campo específico para la URL del yate (`#yachtUrl`) y el botón **Create Template** (`#createTemplateButton`). El campo está definido como `type="url"` con un `pattern` que obliga a iniciar con `http` o `https`, evitando entradas sin protocolo【F:app_yacht/modules/calc/calculator.php†L172-L176】.
-- `template.js` valida esa entrada en tiempo real: habilita o deshabilita el botón según una expresión regular con protocolo y registra un listener para invocar `templateManager.createTemplate()` al hacer clic【F:app_yacht/modules/template/js/template.js†L270-L276】【F:app_yacht/modules/template/js/template.js†L385-L387】.
+- El formulario del módulo de cálculo incluye un campo para la URL del yate (`#yachtUrl`) y el botón **Create Template** (`#createTemplateButton`). El campo se define como `type="url"` con un `pattern` que exige iniciar con `http` o `https`【F:app_yacht/modules/calc/calculator.php†L172-L180】.
+- `template.js` monitorea el campo, habilita o deshabilita el botón según una expresión regular con protocolo y registra un listener que ejecuta `templateManager.createTemplate()` al hacer clic【F:app_yacht/modules/template/js/template.js†L270-L276】【F:app_yacht/modules/template/js/template.js†L385-L387】.
 
 ## 2. Recolección y envío de datos desde el frontend
-- `TemplateManager.collectFormData()` reúne los campos del formulario y añade la URL del yate al objeto `FormData`【F:app_yacht/shared/js/classes/TemplateManager.js†L52-L65】.
-- `TemplateManager.createTemplate()` valida la información y realiza una petición `fetch` `POST` a la URL AJAX definida, enviando el `FormData` construido【F:app_yacht/shared/js/classes/TemplateManager.js†L212-L260】.
+- `TemplateManager.collectFormData()` reúne los datos del formulario y añade la URL del yate al objeto `FormData`【F:app_yacht/shared/js/classes/TemplateManager.js†L52-L65】.
+- `TemplateManager.createTemplate()` valida la información, realiza una petición `fetch` `POST` a la URL de AJAX con el `FormData` y, si la respuesta es exitosa, inserta el HTML generado en `#result` y activa el botón de copiado【F:app_yacht/shared/js/classes/TemplateManager.js†L212-L276】.
 
 ## 3. Procesamiento en el backend y scraping de la información del yate
-- `AppYachtBootstrap::handleCreateTemplate()` atiende la solicitud AJAX: obtiene el servicio de renderizado, recupera la URL del yate de `$_POST` y delega la extracción de datos al módulo `YachtInfoService`【F:app_yacht/core/bootstrap.php†L187-L201】.
-- `YachtInfoService::extractYachtInfo()` valida la URL, comprueba dominios permitidos, utiliza caché y ejecuta el scraping para devolver un arreglo con los datos principales del yate【F:app_yacht/modules/yachtinfo/yacht-info-service.php†L36-L70】.
+- `AppYachtBootstrap::handleCreateTemplate()` atiende la solicitud, obtiene los servicios de renderizado y de información del yate, y delega la extracción de datos a `YachtInfoService` si se recibió una URL【F:app_yacht/core/bootstrap.php†L187-L201】.
+- `YachtInfoService::extractYachtInfo()` valida la URL, comprueba dominios permitidos, aplica caché y realiza el scraping para devolver un arreglo con los datos principales del yate【F:app_yacht/modules/yachtinfo/yacht-info-service.php†L36-L70】.
 
 ## 4. Preparación de datos y renderizado de la plantilla
-- `RenderEngine::createTemplate()` combina los datos del formulario con la información del yate recibida para generar el contenido HTML y de texto de la plantilla seleccionada【F:app_yacht/modules/render/render-engine.php†L128-L160】.
+- `RenderEngine::createTemplate()` combina los datos del formulario con la información del yate y genera el contenido HTML y de texto de la plantilla seleccionada【F:app_yacht/modules/render/render-engine.php†L128-L160】.
 - `default-template.php` utiliza `buildYachtInfoArray()` para estructurar la información del yate y luego imprime campos como eslora, tipo, constructor, año, tripulación, cabinas y huéspedes【F:app_yacht/modules/template/templates/default-template.php†L29-L72】【F:app_yacht/modules/template/templates/default-template.php†L136-L138】.
 
 ## 5. Inserción del HTML en el frontend
-- Tras recibir la respuesta JSON exitosa, `TemplateManager.createTemplate()` reemplaza el contenido del contenedor `#result` con el HTML generado, mostrando la plantilla con los datos del yate en pantalla【F:app_yacht/shared/js/classes/TemplateManager.js†L266-L270】.
+- Tras recibir la respuesta, `TemplateManager.createTemplate()` reemplaza el contenido del contenedor `#result` con el HTML generado, mostrando la plantilla con los datos del yate en pantalla【F:app_yacht/shared/js/classes/TemplateManager.js†L266-L270】.
 
 Este flujo asegura que, al ingresar una URL válida y presionar **Create Template**, la aplicación extrae la información del yate, la combina con los cálculos y la muestra mediante la plantilla por defecto en el frontend.
+

--- a/app_yacht/modules/calc/calculator.php
+++ b/app_yacht/modules/calc/calculator.php
@@ -169,10 +169,11 @@
 						<button type="button" class="btn btn-primary w-100 mt-4" id="copyButton" onclick="copyToClipboard()" disabled>Copy Result</button>
 					</div>
 
-					  <!-- Campo Yacht URL -->
-					<div class="col-12 col-md-3 col-lg-2 p-1">
-						<input type="text" id="yachtUrl" name="yachtUrl" class="form-control w-100 mt-4" placeholder="Yacht URL" required>
-					</div>
+                                         <!-- Campo Yacht URL -->
+                                       <div class="col-12 col-md-3 col-lg-2 p-1">
+                                               <label for="yachtUrl" class="form-label mt-4">Yacht URL</label>
+                                               <input type="url" id="yachtUrl" name="yachtUrl" class="form-control w-100" placeholder="https://example.com" pattern="https?://.+" required>
+                                       </div>
 
 					<!-- Botón Create Template -->
 					<div class="col-6 col-md-3 col-lg-2 p-1">

--- a/app_yacht/modules/template/js/template.js
+++ b/app_yacht/modules/template/js/template.js
@@ -271,7 +271,7 @@ function toggleCreateTemplateButton() {
     const yachtUrlInput = document.getElementById('yachtUrl');
     const createTemplateButton = document.getElementById('createTemplateButton');
     if (!yachtUrlInput || !createTemplateButton) return;
-    const urlPattern = /^(https?:\/\/)?([\w-]+\.)+[\w-]{2,}(\/\S*)?$/;
+    const urlPattern = /^https?:\/\/(?:[\w-]+\.)+[\w-]{2,}(\/\S*)?$/;
     const yachtUrl = yachtUrlInput.value.trim();
     createTemplateButton.disabled = !(yachtUrl && urlPattern.test(yachtUrl));
 }


### PR DESCRIPTION
## Summary
- document YachtInfoService-based scraping and rendering flow
- add URL input with protocol validation and stricter front-end regex

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688efda0afa08329820ea13c46871ee9