### PR TITLE
Remove outdated PHP documentation comments

### DIFF
--- a/404.php
+++ b/404.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * The template for displaying 404 pages (not found)
- *
- * @link https://codex.wordpress.org/Creating_an_Error_404_Page
- *
- * @package ProBroke
- */
+
 
 get_header();
 ?>
@@ -44,7 +38,7 @@ get_header();
 					</div><!-- .widget -->
 
 					<?php
-					/* translators: %1$s: smiley */
+					
 					$creativoypunto_archive_content = '<p>' . sprintf( esc_html__( 'Try looking in the monthly archives. %1$s', 'creativoypunto' ), convert_smilies( ':)' ) ) . '</p>';
 					the_widget( 'WP_Widget_Archives', 'dropdown=1', "after_title=</h2>$creativoypunto_archive_content" );
 

--- a/app-empleadosQR.php
+++ b/app-empleadosQR.php
@@ -1,7 +1,5 @@
 <?php
-/*
-Template Name: App Empleados QR
-*/
+
 get_header();
 get_template_part( 'app_empleadosQR/templates/employee-dashboard' );
 get_footer();

--- a/app-mail.php
+++ b/app-mail.php
@@ -1,12 +1,9 @@
 <?php
-/**
- * Template Name: App mail
- * Description: Plantilla para la app de correos personales (Gmail, etc.)
- */
+
 
 get_header();
 
-// Incluir la app principal
+
 get_template_part( 'app_mail/core/app-mail' );
 
 get_footer();

--- a/app-yacht.php
+++ b/app-yacht.php
@@ -1,7 +1,5 @@
 <?php
-/*
-Template Name: App Yacht
-*/
+
 get_header(); 
 
 get_template_part( 'app_yacht/core/app-yacht' );

--- a/app_yacht/core/api-request.php
+++ b/app_yacht/core/api-request.php
@@ -1,24 +1,13 @@
 <?php
-/**
- * FILE core/api-request.php
- * Implements functions for secure HTTP requests in the app_yacht application
- */
 
-/**
- * Handles secure HTTP requests for the app_yacht application.
- */
+
+
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; 
 }
 
-/**
- * Makes secure HTTP requests with robust error handling.
- *
- * @param string $url The URL for the request.
- * @param array  $args Arguments for wp_remote_request.
- * @return array Structured response with success/error details.
- */
+
 function pb_make_api_request( $url, $args = array() ) {
 	if ( ! isset( $args['timeout'] ) ) {
 		$args['timeout'] = 15;
@@ -68,12 +57,7 @@ function pb_make_api_request( $url, $args = array() ) {
 	);
 }
 
-/**
- * Returns the appropriate timeout for different request types.
- *
- * @param string $request_type Request type (default, outlook_api, file_upload, long_process).
- * @return int Timeout in seconds.
- */
+
 function pb_get_request_timeout( $request_type = 'default' ) {
 	$timeouts = array(
 		'default'      => 15,

--- a/app_yacht/core/app-yacht.php
+++ b/app_yacht/core/app-yacht.php
@@ -1,25 +1,17 @@
 <?php
-/**
- * 
- * ARCHIVO core/app-yacht.php
- * Punto de entrada principal para la aplicación App_Yacht
- * REFACTORIZADO - Versión 2.0.0 con nueva arquitectura
- * 
- * @package AppYacht
- * @version 2.0.0
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; 
 }
 
-// Cargar nueva arquitectura
+
 require_once __DIR__ . '/bootstrap.php';
 
-// Inicializar la aplicación
+
 $container = AppYachtBootstrap::init();
 
-// Cargar archivos de compatibilidad si existen
+
 $legacy_files = array(
 	get_template_directory() . '/app_yacht/core/security-headers.php',
 	get_template_directory() . '/app_yacht/core/data-validation.php',
@@ -34,14 +26,14 @@ foreach ( $legacy_files as $file ) {
 
 echo '<div class="container">';
 
-// Incluir las vistas de los módulos (UI mantiene compatibilidad)
+
 require get_template_directory() . '/app_yacht/modules/calc/calculator.php';
 require get_template_directory() . '/app_yacht/modules/template/template.php';
 require get_template_directory() . '/app_yacht/modules/mail/mail.php';
 
 echo '</div>';
 
-// Agregar información de debug en modo desarrollo
+
 if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 	echo '<!-- App Yacht v2.0.0 - Nueva Arquitectura Cargada -->';
 	echo '<!-- Servicios registrados: ' . implode( ', ', $container->getRegisteredServices() ) . ' -->';

--- a/app_yacht/core/bootstrap.php
+++ b/app_yacht/core/bootstrap.php
@@ -1,63 +1,49 @@
 <?php
-/**
- * Bootstrap principal para la aplicación App_Yacht
- * Inicializa el contenedor DI y los servicios principales
- * 
- * @package AppYacht
- * @version 2.0.0
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; 
 }
 
-// Incluir el contenedor DI
+
 require_once __DIR__ . '/container.php';
 require_once __DIR__ . '/config.php';
 
-// Incluir interfaces
+
 require_once __DIR__ . '/../shared/interfaces/yacht-info-service-interface.php';
 require_once __DIR__ . '/../shared/interfaces/calc-service-interface.php';
 require_once __DIR__ . '/../shared/interfaces/render-engine-interface.php';
 require_once __DIR__ . '/../shared/interfaces/mail-service-interface.php';
 
-// Incluir servicios
+
 require_once __DIR__ . '/../modules/yachtinfo/yacht-info-service.php';
 require_once __DIR__ . '/../modules/calc/calc-service.php';
 require_once __DIR__ . '/../modules/render/render-engine.php';
 require_once __DIR__ . '/../modules/mail/mail-service.php';
 
-/**
- * Clase principal de Bootstrap para App_Yacht
- */
+
 class AppYachtBootstrap {
 	
-	/**
-	 * @var AppYachtContainer
-	 */
+	
 	private static $container = null;
 	
-	/**
-	 * @var bool
-	 */
+	
 	private static $initialized = false;
 	
-	/**
-	 * Inicializa la aplicación
-	 */
+	
 	public static function init() {
 		if ( self::$initialized ) {
 			return self::$container;
 		}
 		
 		try {
-			// Crear contenedor
+			
 			self::$container = new AppYachtContainer();
 			
-			// Registrar servicios
+			
 			self::registerServices();
 			
-			// Registrar hooks de WordPress
+			
 			self::registerWordPressHooks();
 			
 			self::$initialized = true;
@@ -70,14 +56,12 @@ class AppYachtBootstrap {
 		}
 	}
 	
-	/**
-	 * Registra los servicios en el contenedor DI
-	 */
+	
 	private static function registerServices() {
 		$container = self::$container;
 		$config    = AppYachtConfig::get();
 		
-		// Registrar YachtInfoService
+		
 		$container->register(
 			'yacht_info_service',
 			function() use ( $config ) {
@@ -85,7 +69,7 @@ class AppYachtBootstrap {
 			}
 		);
 		
-		// Registrar CalcService
+		
 		$container->register(
 			'calc_service',
 			function() use ( $config ) {
@@ -93,7 +77,7 @@ class AppYachtBootstrap {
 			}
 		);
 		
-		// Registrar RenderEngine
+		
 		$container->register(
 			'render_engine',
 			function() use ( $config ) {
@@ -101,7 +85,7 @@ class AppYachtBootstrap {
 			}
 		);
 		
-		// Registrar MailService
+		
 		$container->register(
 			'mail_service',
 			function() use ( $config, $container ) {
@@ -113,11 +97,9 @@ class AppYachtBootstrap {
 		);
 	}
 	
-	/**
-	 * Registra hooks de WordPress para mantener compatibilidad
-	 */
+	
 	private static function registerWordPressHooks() {
-		// Mantener los hooks AJAX existentes para compatibilidad
+		
 		add_action( 'wp_ajax_calculate_charter', array( __CLASS__, 'handleCalculateCharter' ) );
 		add_action( 'wp_ajax_nopriv_calculate_charter', array( __CLASS__, 'handleCalculateCharter' ) );
 		
@@ -131,9 +113,7 @@ class AppYachtBootstrap {
 		add_action( 'wp_ajax_nopriv_createTemplate', array( __CLASS__, 'handleCreateTemplate' ) );
 	}
 	
-	/**
-	 * Obtiene el contenedor DI
-	 */
+	
 	public static function getContainer() {
 		if ( ! self::$initialized ) {
 			self::init();
@@ -141,9 +121,7 @@ class AppYachtBootstrap {
 		return self::$container;
 	}
 	
-	/**
-	 * Handler para AJAX calculate_charter (compatibilidad)
-	 */
+	
 	public static function handleCalculateCharter() {
 		try {
 			$calcService = self::getContainer()->get( 'calc_service' );
@@ -155,9 +133,7 @@ class AppYachtBootstrap {
 		}
 	}
 	
-	/**
-	 * Handler para AJAX calculate_mix (compatibilidad)
-	 */
+	
 	public static function handleCalculateMix() {
 		try {
 			$calcService = self::getContainer()->get( 'calc_service' );
@@ -169,9 +145,7 @@ class AppYachtBootstrap {
 		}
 	}
 	
-	/**
-	 * Handler para AJAX load_template_preview (compatibilidad)
-	 */
+	
 	public static function handleLoadTemplatePreview() {
 		try {
 			$renderEngine = self::getContainer()->get( 'render_engine' );
@@ -183,15 +157,13 @@ class AppYachtBootstrap {
 		}
 	}
 	
-	/**
-	 * Handler para AJAX createTemplate (compatibilidad)
-	 */
+	
 	public static function handleCreateTemplate() {
 		try {
 			$renderEngine     = self::getContainer()->get( 'render_engine' );
 			$yachtInfoService = self::getContainer()->get( 'yacht_info_service' );
 			
-			// Obtener datos del yacht si hay URL
+			
 			$yachtData = null;
 			if ( ! empty( $_POST['yachtUrl'] ) ) {
 				$yachtData = $yachtInfoService->extractYachtInfo( $_POST['yachtUrl'] );

--- a/app_yacht/core/config.php
+++ b/app_yacht/core/config.php
@@ -1,31 +1,17 @@
 <?php
-/**
- * Configuración centralizada para App_Yacht
- * Todas las configuraciones de módulos en un solo lugar
- * 
- * @package AppYacht
- * @version 2.0.0
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Clase de configuración centralizada
- */
+
 class AppYachtConfig {
 	
-	/**
-	 * @var array Configuración por defecto
-	 */
+	
 	private static $config = null;
 	
-	/**
-	 * Obtiene toda la configuración
-	 * 
-	 * @return array
-	 */
+	
 	public static function get( $key = null ) {
 		if ( self::$config === null ) {
 			self::$config = self::loadConfig();
@@ -38,11 +24,7 @@ class AppYachtConfig {
 		return isset( self::$config[ $key ] ) ? self::$config[ $key ] : null;
 	}
 	
-	/**
-	 * Carga la configuración por defecto
-	 * 
-	 * @return array
-	 */
+	
 	private static function loadConfig() {
 		return array(
 			'app' => array(
@@ -66,7 +48,7 @@ class AppYachtConfig {
 				),
 				'timeout'         => 30,
 				'user_agent'      => 'Mozilla/5.0 (compatible; AppYachtBot/2.0)',
-				'cache_duration'  => 3600, // 1 hora
+				'cache_duration'  => 3600, 
 				'max_redirects'   => 3,
 			),
 			
@@ -100,7 +82,7 @@ class AppYachtConfig {
 				),
 				'templates_path'      => get_template_directory() . '/app_yacht/modules/template/templates/',
 				'cache_enabled'       => true,
-				'cache_duration'      => 1800, // 30 minutos
+				'cache_duration'      => 1800, 
 			),
 			
 			'mail' => array(
@@ -108,7 +90,7 @@ class AppYachtConfig {
 				'outlook_enabled'          => true,
 				'signature_enabled'        => true,
 				'max_recipients'           => 50,
-				'attachment_max_size'      => 5 * 1024 * 1024, // 5MB
+				'attachment_max_size'      => 5 * 1024 * 1024, 
 				'allowed_attachment_types' => array( 'pdf', 'doc', 'docx', 'jpg', 'jpeg', 'png' ),
 			),
 			
@@ -117,7 +99,7 @@ class AppYachtConfig {
 				'rate_limit'           => array(
 					'enabled'      => true,
 					'max_requests' => 100,
-					'time_window'  => 3600, // 1 hora
+					'time_window'  => 3600, 
 				),
 				'allowed_capabilities' => array(
 					'edit_yacht_templates',
@@ -135,18 +117,13 @@ class AppYachtConfig {
 			'logging' => array(
 				'enabled'       => true,
 				'level'         => defined( 'WP_DEBUG' ) && WP_DEBUG ? 'debug' : 'error',
-				'max_file_size' => 5 * 1024 * 1024, // 5MB
+				'max_file_size' => 5 * 1024 * 1024, 
 				'max_files'     => 5,
 			),
 		);
 	}
 	
-	/**
-	 * Actualiza un valor de configuración
-	 * 
-	 * @param string $key
-	 * @param mixed  $value
-	 */
+	
 	public static function set( $key, $value ) {
 		if ( self::$config === null ) {
 			self::$config = self::loadConfig();
@@ -155,12 +132,7 @@ class AppYachtConfig {
 		self::$config[ $key ] = $value;
 	}
 	
-	/**
-	 * Obtiene configuración de un módulo específico
-	 * 
-	 * @param string $module
-	 * @return array|null
-	 */
+	
 	public static function getModuleConfig( $module ) {
 		return self::get( $module );
 	}

--- a/app_yacht/core/container.php
+++ b/app_yacht/core/container.php
@@ -1,43 +1,23 @@
 <?php
-/**
- * Contenedor de Inyección de Dependencias para App_Yacht
- * Implementa un contenedor DI simple y eficiente
- * 
- * @package AppYacht
- * @version 2.0.0
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Contenedor DI simple para servicios de App_Yacht
- */
+
 class AppYachtContainer {
 	
-	/**
-	 * @var array Servicios registrados
-	 */
+	
 	private $services = array();
 	
-	/**
-	 * @var array Instancias singleton
-	 */
+	
 	private $instances = array();
 	
-	/**
-	 * @var array Servicios marcados como singleton
-	 */
+	
 	private $singletons = array();
 	
-	/**
-	 * Registra un servicio en el contenedor
-	 * 
-	 * @param string   $name Nombre del servicio
-	 * @param callable $factory Factory function que crea el servicio
-	 * @param bool     $singleton Si debe ser singleton
-	 */
+	
 	public function register( $name, callable $factory, $singleton = true ) {
 		$this->services[ $name ] = $factory;
 		
@@ -46,29 +26,23 @@ class AppYachtContainer {
 		}
 	}
 	
-	/**
-	 * Obtiene un servicio del contenedor
-	 * 
-	 * @param string $name Nombre del servicio
-	 * @return mixed
-	 * @throws Exception Si el servicio no está registrado
-	 */
+	
 	public function get( $name ) {
-		// Si es singleton y ya existe la instancia
+		
 		if ( isset( $this->singletons[ $name ] ) && isset( $this->instances[ $name ] ) ) {
 			return $this->instances[ $name ];
 		}
 		
-		// Si el servicio no está registrado
+		
 		if ( ! isset( $this->services[ $name ] ) ) {
 			throw new Exception( "Servicio '{$name}' no está registrado en el contenedor DI" );
 		}
 		
-		// Crear la instancia
+		
 		$factory  = $this->services[ $name ];
 		$instance = $factory( $this );
 		
-		// Guardar como singleton si corresponde
+		
 		if ( isset( $this->singletons[ $name ] ) ) {
 			$this->instances[ $name ] = $instance;
 		}
@@ -76,39 +50,24 @@ class AppYachtContainer {
 		return $instance;
 	}
 	
-	/**
-	 * Verifica si un servicio está registrado
-	 * 
-	 * @param string $name Nombre del servicio
-	 * @return bool
-	 */
+	
 	public function has( $name ) {
 		return isset( $this->services[ $name ] );
 	}
 	
-	/**
-	 * Elimina un servicio del contenedor
-	 * 
-	 * @param string $name Nombre del servicio
-	 */
+	
 	public function remove( $name ) {
 		unset( $this->services[ $name ] );
 		unset( $this->instances[ $name ] );
 		unset( $this->singletons[ $name ] );
 	}
 	
-	/**
-	 * Obtiene todos los servicios registrados
-	 * 
-	 * @return array
-	 */
+	
 	public function getRegisteredServices() {
 		return array_keys( $this->services );
 	}
 	
-	/**
-	 * Limpia todas las instancias singleton (útil para testing)
-	 */
+	
 	public function clearInstances() {
 		$this->instances = array();
 	}

--- a/app_yacht/core/data-validation.php
+++ b/app_yacht/core/data-validation.php
@@ -1,20 +1,11 @@
 <?php
-/**
- * FILE core/data-validation.php
- * Sanitization and validation functions for the app_yacht application.
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; 
 }
 
-/**
- * Sanitizes input data based on the specified type.
- *
- * @param mixed  $data The data to sanitize.
- * @param string $type The data type (email, url, number, int, html, textarea, array, text).
- * @return mixed Sanitized data.
- */
+
 function pb_sanitize_input( $data, $type = 'text' ) {
 	switch ( $type ) {
 		case 'email':

--- a/app_yacht/core/security-headers.php
+++ b/app_yacht/core/security-headers.php
@@ -1,24 +1,18 @@
 <?php
-/**
- * File core/security-headers.php
- * Implements security headers for the app_yacht application.
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; 
 }
 
-/**
- * Adds security headers to HTTP responses.
- * Includes protections against clickjacking, XSS, MIME sniffing, and more.
- */
+
 function pb_add_security_headers() {
-	header( 'X-Frame-Options: SAMEORIGIN' ); // Prevent clickjacking
-	header( 'X-XSS-Protection: 1; mode=block' ); // Enable XSS protection
-	header( 'X-Content-Type-Options: nosniff' ); // Prevent MIME sniffing
-	header( 'Content-Security-Policy: default-src \'self\'; script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://cdn.jsdelivr.net; style-src \'self\' \'unsafe-inline\' https://fonts.googleapis.com; font-src \'self\' https://fonts.gstatic.com; img-src \'self\' data: https:; connect-src \'self\' https://api.example.com;' ); // Restrict content sources
-	header( 'Strict-Transport-Security: max-age=31536000; includeSubDomains; preload' ); // Enforce HTTPS
-	header( 'Referrer-Policy: strict-origin-when-cross-origin' ); // Control referrer information
+	header( 'X-Frame-Options: SAMEORIGIN' ); 
+	header( 'X-XSS-Protection: 1; mode=block' ); 
+	header( 'X-Content-Type-Options: nosniff' ); 
+	header( 'Content-Security-Policy: default-src \'self\'; script-src \'self\' \'unsafe-inline\' \'unsafe-eval\' https://cdn.jsdelivr.net; style-src \'self\' \'unsafe-inline\' https://fonts.googleapis.com; font-src \'self\' https://fonts.gstatic.com; img-src \'self\' data: https:; connect-src \'self\' https://api.example.com;' ); 
+	header( 'Strict-Transport-Security: max-age=31536000; includeSubDomains; preload' ); 
+	header( 'Referrer-Policy: strict-origin-when-cross-origin' ); 
 }
 
 add_action( 'send_headers', 'pb_add_security_headers' );

--- a/app_yacht/core/yacht-functions.php
+++ b/app_yacht/core/yacht-functions.php
@@ -1,18 +1,10 @@
 <?php
-/**
- * File core\yacht-functions.php
- * Core functions for the app_yacht application.
- * Handles script/style enqueuing, AJAX actions, Outlook authentication, and role capabilities.
- */
+
 
 require_once get_template_directory() . '/app_yacht/shared/php/utils.php';
 require_once get_template_directory() . '/app_yacht/shared/php/security.php';
 
-/**
- * Enqueues JavaScript files for the app_yacht page.
- * Loads shared and module-specific scripts, and localizes AJAX data.
- * Only runs on the 'app-yacht.php' page template.
- */
+
 function app_yacht_scripts() {
 	if ( is_page_template( 'app-yacht.php' ) ) {
 		$dependencies = array( 'jquery' );
@@ -125,11 +117,7 @@ function app_yacht_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'app_yacht_scripts' );
 
-/**
- * Enqueues CSS files for the app_yacht page.
- * Loads global and module-specific styles.
- * Only runs on the 'app-yacht.php' page template.
- */
+
 function app_yacht_css() {
 	if ( is_page_template( 'app-yacht.php' ) ) {
 		wp_enqueue_style( 'app-yacht-styles', get_template_directory_uri() . '/app_yacht/shared/css/app_yacht.css', array(), '1.0.0' );
@@ -139,10 +127,7 @@ function app_yacht_css() {
 }
 add_action( 'wp_enqueue_scripts', 'app_yacht_css' );
 
-/**
- * Dynamically loads PHP files based on context.
- * Loads files for calc, template, and mail modules in app-yacht.php, AJAX, or Outlook auth contexts.
- */
+
 $load_appyacht_php = false;
 if ( is_page_template( 'app-yacht.php' ) ) {
 	$load_appyacht_php = true;
@@ -162,10 +147,7 @@ if ( $load_appyacht_php ) {
 
 require_once get_template_directory() . '/app_yacht/modules/mail/outlook/outlook-loader.php';
 
-/**
- * Registers AJAX actions for calc, template, and mail modules.
- * Handles calculations, template creation, email sending, and signature management.
- */
+
 add_action( 'wp_ajax_calculate_charter', 'handle_calculate_charter' );
 add_action( 'wp_ajax_nopriv_calculate_charter', 'handle_calculate_charter' );
 add_action( 'wp_ajax_calculate_mix', 'handle_calculate_mix' );
@@ -181,20 +163,13 @@ add_action( 'wp_ajax_nopriv_pb_outlook_disconnect', 'pb_outlook_disconnect_ajax_
 add_action( 'wp_ajax_msp_save_signature', 'msp_save_signature_callback' );
 add_action( 'wp_ajax_msp_delete_signature', 'msp_delete_signature_callback' );
 
-/**
- * Registers the /appyacht/auth/ endpoint for Outlook authentication.
- * Adds the 'auth' rewrite rule to WordPress.
- */
+
 function pb_add_auth_rewrite_endpoint() {
 	add_rewrite_endpoint( 'auth', EP_ROOT | EP_PAGES );
 }
 add_action( 'init', 'pb_add_auth_rewrite_endpoint' );
 
-/**
- * Handles the Outlook authentication callback at /appyacht/auth/.
- * Exchanges authorization code for tokens and saves them to the user.
- * Redirects to the app_yacht page on success or failure.
- */
+
 function pb_handle_auth_endpoint() {
 	global $wp_query;
 
@@ -233,11 +208,7 @@ function pb_handle_auth_endpoint() {
 }
 add_action( 'template_redirect', 'pb_handle_auth_endpoint' );
 
-/**
- * Registers custom capabilities for WordPress roles.
- * Assigns 'edit_yacht_templates' and 'send_yacht_emails' to administrator, editor, and author roles.
- * Runs on theme activation and immediately for consistency.
- */
+
 function pb_register_yacht_roles_capabilities() {
 	$admin_caps = array(
 		'edit_yacht_templates',

--- a/app_yacht/default-template.php
+++ b/app_yacht/default-template.php
@@ -1,32 +1,13 @@
 <?php
-/**
- * Default Email Template (Main Version).
- *
- * This template generates the main HTML email body for yacht charter details.
- * It receives data via the $templateData variable, processes it using helper functions,
- * and populates the HTML structure.
- *
- * @package App_Yacht
- * @subpackage Modules
- * @since 1.0.0
- *
- * @uses buildYachtInfoArray() To structure yacht details.
- * @uses buildCalcSnippetArray() To structure calculation results.
- *
- * @var array $templateData Associative array containing all necessary data:
- *        'yachtInfo'      => (array) Yacht details.
- *        'resultArray'    => (array) Calculation results.
- *        'lowSeasonText'  => (string) Text for low season.
- *        'highSeasonText' => (string) Text for high season.
- */
 
-// Verify received data
+
+
 if ( empty( $templateData['resultArray'] ) ) {
 	error_log( 'Empty resultArray in default-template.php' );
 	error_log( 'Template data: ' . print_r( $templateData, true ) );
 }
 
-// Prepare data arrays using helper functions
+
 $yachtArr = buildYachtInfoArray( $templateData['yachtInfo'] ?? array() );
 $calcArr  = buildCalcSnippetArray(
 	$templateData['resultArray'] ?? array(),
@@ -34,13 +15,13 @@ $calcArr  = buildCalcSnippetArray(
 	$templateData['highSeasonText'] ?? ''
 );
 
-// Verify processed data
+
 if ( empty( $calcArr['structuredBlock'] ) ) {
 	error_log( 'Empty structuredBlock in default-template.php' );
 	error_log( 'Calc array: ' . print_r( $calcArr, true ) );
 }
 
-// Extract the main structured block for easier access in the template
+
 $block = $calcArr['structuredBlock'] ?? array();
 ?>
 <!-- Template que debe copiarse con el botón Copy Template inicio -->
@@ -113,7 +94,7 @@ $block = $calcArr['structuredBlock'] ?? array();
 								<div id="imageSection" class="template-img-section" style="max-width: 395px; min-width: 300px; display: table-cell; vertical-align: top;">
 									<?php
 									if ( ! empty( $yachtArr['imageUrl'] ) ) :
-										// Añadido width: 100%; para asegurar expansión completa
+										
 										?>
 										<div style="color:#ffffff;border-top-left-radius: 6px; border-top-right-radius: 5px; border-bottom-right-radius: 50px; border-bottom-left-radius: 0px;font-size:20px;display:block;border-bottom: 4px solid #ffbe28;background: #4092df; width: 100%;">
 											<a class="template-yacht-name" href="<?php echo htmlspecialchars( $yachtArr['yachtUrl'] ); ?>" id="yachtLink" style="color:#ffffff;font-weight:bold;text-decoration:none;">
@@ -215,7 +196,7 @@ $block = $calcArr['structuredBlock'] ?? array();
 														<td align="left" valign="middle" style="padding: 5px; color: #4b4f54; width: 70%;">
 															<?php if ( $resultData['discountType'] === 'percentage' ) : ?>
 																Discount Rate (<?php echo htmlspecialchars( number_format( floatval( str_replace( array( ',', '%' ), '', $resultData['discountAmount'] ) ), 0, '.', ',' ) ); ?>%):
-															<?php else : // Assuming 'fixed' ?>
+															<?php else : ?>
 																Discount Rate: - <?php echo htmlspecialchars( $resultData['discountAmount'] ); ?> :
 															<?php endif; ?>
 														</td>
@@ -357,7 +338,7 @@ $block = $calcArr['structuredBlock'] ?? array();
 
 
 											<!-- Extras -->
-											<?php if ( ! empty( $resultData['extras'] ) ) : // Show Extras section only if there are extras ?>
+											<?php if ( ! empty( $resultData['extras'] ) ) : ?>
 												<table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0"
 													style="width: 100%; border-spacing: 0; border-collapse: collapse; padding: 2px 5px; color: #4b4f54; font-family: Arial, sans-serif; font-size: 12px; margin-top: 5px;">
 													<!-- Extras Title Row -->
@@ -378,9 +359,9 @@ $block = $calcArr['structuredBlock'] ?? array();
 																</td>
 															</tr>
 														<?php endforeach; ?>
-													<?php endif; // End hideExtras condition ?>
+													<?php endif; ?>
 												</table>
-											<?php endif; // End !empty($resultData['extras']) condition ?>
+											<?php endif; ?>
 
 
 											<!-- Grand Total -->

--- a/app_yacht/modules/calc/php/calculate.php
+++ b/app_yacht/modules/calc/php/calculate.php
@@ -1,65 +1,20 @@
 <?php
-/**
- * Backend handler for charter rate calculations via AJAX for AppYacht.
- *
- * @author Mr ShadoW <mrshadow@probroker.com>
- * @copyright 2024 Pro Broker
- * @link /DOC/modules/calc/php/calculate.php.md
- * @version 3.0
- */
-// Archivo: modules/calc/php/calculate.php
 
-// IMPORTANTE: La lógica de propina varía según la moneda:
-// EUR => 10%-15%
-// Otras (USD, AUD, etc.) => 15%-20%
 
-require_once __DIR__ . '/../../../shared/php/currency-functions.php'; // Para formatCurrency
 
-// Registrar acciones AJAX
+
+
+
+
+require_once __DIR__ . '/../../../shared/php/currency-functions.php'; 
+
+
 add_action( 'wp_ajax_calculate_charter', 'handle_calculate_charter' );
 add_action( 'wp_ajax_nopriv_calculate_charter', 'handle_calculate_charter' );
 
-/**
- * Handles AJAX requests for charter rate calculations (`calculate_charter` action).
- *
- * This function serves as the main AJAX handler. It performs security checks (nonce),
- * collects and sanitizes input data from `$_POST`, prepares data for calculation,
- * invokes the `calculate()` function for core computation, formats the results
- * using `textResult()`, and then sends a JSON response (success or error) back to the client.
- *
- * @since 1.0.0
- *
- * @global array $_POST Expected superglobal. Expected keys include:
- *  'nonce' (string) Security nonce.
- *  'currency' (string) Currency symbol (e.g., '€', '$USD').
- *  'vatRate' (string) VAT rate percentage.
- *  'apaAmount' (string) Fixed APA amount.
- *  'apaPercentage' (string) APA percentage.
- *  'relocationFee' (string) Relocation fee.
- *  'securityFee' (string) Security deposit fee.
- *  'charterRates' (array) Array of charter rate blocks.
- *  'extras' (array) Array of extras.
- *  'enableMixedSeasons' (string) '1' if mixed seasons mode is enabled.
- *  'enableOneDayCharter' (string) '1' if one-day charter mode is enabled.
- *  'enableExpenses' (string) '1' if '+ Expenses' label should be shown.
- *  'hideVAT' (string) '1' to hide VAT details.
- *  'hideAPA' (string) '1' to hide APA details.
- *  'hideRelocation' (string) '1' to hide relocation fee details.
- *  'hideSecurity' (string) '1' to hide security deposit details.
- *  'hideExtras' (string) '1' to hide extras details.
- *  'hideGratuity' (string) '1' to hide gratuity details.
- *
- * @uses wp_verify_nonce() For security validation.
- * @uses sanitize_text_field() For input sanitization.
- * @uses calculate() For performing the core calculations.
- * @uses textResult() For formatting the calculation results into text.
- * @uses wp_send_json_error() For sending error responses.
- * @uses wp_send_json_success() For sending success responses.
- *
- * @return void Outputs JSON and terminates execution.
- */
+
 function handle_calculate_charter() {
-	// 1) Verificar nonce para seguridad
+	
 	if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'calculate_nonce' ) ) {
 		wp_send_json_error( array( 'error' => 'Nonce inválido.' ), 400 );
 		return;
@@ -67,7 +22,7 @@ function handle_calculate_charter() {
 
 
 
-	// Recoger y sanitizar datos de $_POST
+	
 	$currency            = isset( $_POST['currency'] ) ? sanitize_text_field( $_POST['currency'] ) : '';
 	$vatRate             = isset( $_POST['vatRate'] ) ? sanitize_text_field( $_POST['vatRate'] ) : '';
 	$apaAmount           = isset( $_POST['apaAmount'] ) ? sanitize_text_field( $_POST['apaAmount'] ) : '';
@@ -80,7 +35,7 @@ function handle_calculate_charter() {
 	$enableOneDayCharter = ! empty( $_POST['enableOneDayCharter'] ) && $_POST['enableOneDayCharter'] === '1';
 	$enableExpenses      = ! empty( $_POST['enableExpenses'] ) && $_POST['enableExpenses'] === '1';
 	
-	// Recoger preferencias de elementos a ocultar
+	
 	$hideElements = array(
 		'hideVAT'        => isset( $_POST['hideVAT'] ) && $_POST['hideVAT'] === '1',
 		'hideAPA'        => isset( $_POST['hideAPA'] ) && $_POST['hideAPA'] === '1',
@@ -90,13 +45,13 @@ function handle_calculate_charter() {
 		'hideGratuity'   => isset( $_POST['hideGratuity'] ) && $_POST['hideGratuity'] === '1',
 	);
 
-	// Validar si $charterRates es un array
+	
 	if ( ! is_array( $charterRates ) ) {
 		wp_send_json_error( array( 'error' => 'charterRates no es un array.' ), 400 );
 		return;
 	}
 
-	// Mapeo de símbolos
+	
 	$symbolsMap = array(
 		'€'    => 'EUR',
 		'$USD' => 'USD',
@@ -104,7 +59,7 @@ function handle_calculate_charter() {
 	);
 	$symbolCode = isset( $symbolsMap[ $currency ] ) ? $symbolsMap[ $currency ] : 'EUR';
 
-	// Recoger enableMixedTaxes y arrays para impuestos mixtos
+	
 	$enableVatRateMix = ! empty( $_POST['vatRateMix'] ) && $_POST['vatRateMix'] === '1';
 	$vatMix           = array();
 	if ( $enableVatRateMix ) {
@@ -121,7 +76,7 @@ function handle_calculate_charter() {
 		error_log( 'VatMix constructed: ' . print_r( $vatMix, true ) );
 	}
 
-	// 3) Construir array de datos a pasar a "calculate"
+	
 	$data = array(
 		'currency'            => $currency,
 		'symbolCode'          => $symbolCode,
@@ -139,18 +94,18 @@ function handle_calculate_charter() {
 		'enableVatRateMix'    => $enableVatRateMix,
 	);
 
-	// 4) Calcular => array estructurado
+	
 	$calcArray = calculate( $data );
 
-	// 5) Generar salida en texto plano
+	
 	$textOutput = textResult( $calcArray, $hideElements, $enableExpenses, $enableMixedSeasons );
 
-	// 6) Responder con JSON
+	
 	wp_send_json_success( $textOutput );
 }
 
 function calculate( array $data ): array {
-	// 1) Parsear inputs
+	
 	$currency     = $data['currency'] ?? '€';
 	$symbolCode   = $data['symbolCode'] ?? 'EUR';
 	$vatRateStr   = $data['vatRate'] ?? '0';
@@ -178,7 +133,7 @@ function calculate( array $data ): array {
 
 	$structuredResults = array();
 
-	// 2) Recorrer "charterRates" para calcular cada bloque
+	
 	foreach ( $charterRates as $rate ) {
 		$guests = (int) ( $rate['guests'] ?? 0 );
 		$nights = (int) ( $rate['nights'] ?? 0 );
@@ -191,39 +146,39 @@ function calculate( array $data ): array {
 		$discountAmount = isset( $rate['discountAmount'] ) ? floatval( str_replace( ',', '', $rate['discountAmount'] ) ) : 0;
 		$discountActive = ( ! empty( $rate['discountActive'] ) && $rate['discountActive'] === '1' );
 
-		// 3) Cálculo base:
+		
 		if ( $oneDayActive ) {
-			// One Day: Se redondea
+			
 			$calculatedBaseRate = ceil( $baseRate );
 		} else {
 			if ( $mixedActive ) {
-				// Modo mix (base)
+				
 				$calculatedBaseRate = ceil( ( $baseRate * 7 ) / 7 );
 			} else {
-				// Modo normal
+				
 				$divisor            = ( $nights <= 5 ) ? 6 : 7;
 				$calculatedBaseRate = ceil( ( $baseRate * $nights ) / $divisor );
 			}
 		}
 
-		// 4) Descuento
+		
 		$discountedRate           = $calculatedBaseRate;
-		$discountValueDisplay     = '--'; // Valor a mostrar como descuento aplicado
-		$discountAmountForDisplay = $discountAmount; // Valor original (porcentaje o fijo)
+		$discountValueDisplay     = '--'; 
+		$discountAmountForDisplay = $discountAmount; 
 
 		if ( $discountActive && $discountAmount > 0 && $discountType !== '' ) {
 			if ( $discountType === 'percentage' ) {
 				$descValue                = $calculatedBaseRate * ( $discountAmount / 100 );
 				$discountedRate           = $calculatedBaseRate - $descValue;
-				$discountValueDisplay     = formatCurrency( $descValue, $symbolCode, true ); // Mostrar el valor calculado del descuento
-				$discountAmountForDisplay = (string) $discountAmount; // Mantener el porcentaje para mostrar
+				$discountValueDisplay     = formatCurrency( $descValue, $symbolCode, true ); 
+				$discountAmountForDisplay = (string) $discountAmount; 
 			} else {
-				// Monto fijo
+				
 				$discountedRate           = $calculatedBaseRate - $discountAmount;
-				$discountValueDisplay     = formatCurrency( $discountAmount, $symbolCode, true ); // Mostrar el monto fijo
-				$discountAmountForDisplay = formatCurrency( $discountAmount, $symbolCode, true ); // Mantener el monto fijo formateado
+				$discountValueDisplay     = formatCurrency( $discountAmount, $symbolCode, true ); 
+				$discountAmountForDisplay = formatCurrency( $discountAmount, $symbolCode, true ); 
 			}
-			// Asegurar que el descuento no resulte en un valor negativo
+			
 			if ( $discountedRate < 0 ) {
 				$discountedRate = 0;
 			}
@@ -243,10 +198,10 @@ function calculate( array $data ): array {
 			 $promotionValueDisplay = formatCurrency( $promotedRate, $symbolCode, true );
 		}
 
-		// 5) Subtotal (base para cálculos de impuestos)
+		
 		$subtotal = $promotedRate;
 
-		// 6) Calcular VAT y APA porcentual basados en el discountedRate
+		
 		$vatCalc     = $promotedRate * $vatRate;
 		$apaPercCalc = $promotedRate * $apaPercentage;
 
@@ -256,7 +211,7 @@ function calculate( array $data ): array {
 		$vatToApply = $vatCalc;
 		$apaToApply = $apaPercCalc;
 
-		// 7) Desglose para VAT Rate Mix (si aplica)
+		
 		if ( $enableVatRateMix && ! empty( $vatMix ) ) {
 			$total_nights_in_post = 0;
 			foreach ( $vatMix as $tax ) {
@@ -287,15 +242,15 @@ function calculate( array $data ): array {
 			}
 		}
 
-		// Sumar VAT y APA porcentual al subtotal
+		
 		$subtotal += $vatToApply;
 		$subtotal += $apaToApply;
 
-		// Sumar Relocation y Security al subtotal
+		
 		$subtotal += $relocationFee;
 		$subtotal += $securityFee;
 		
-		// 8) APA fijo (se suma al final del subtotal)
+		
 		$apaAmountDisp = '';
 		if ( $apaAmount > 0 ) {
 			$subtotal     += $apaAmount;
@@ -304,29 +259,29 @@ function calculate( array $data ): array {
 			$apaAmountDisp = '--';
 		}
 
-		// 9) Relocation Display (ya sumado al subtotal)
+		
 		$relocationDisp = '';
 		if ( $relocationFee > 0 ) {
 			$relocationDisp = formatCurrency( $relocationFee, $symbolCode, false );
 		}
 
-		// 10) Security Display (ya sumado al subtotal)
+		
 		$securityDisp = '';
 		if ( $securityFee > 0 ) {
 			$securityDisp = formatCurrency( $securityFee, $symbolCode, false );
 		}
 
-		// 11) Subtotal final para display
+		
 		$subtotalDisp = formatCurrency( $subtotal, $symbolCode, true );
 
-		// Actualizar variables de display para VAT y APA
+		
 		$vatDisplay  = ( $vatToApply > 0 ) ? formatCurrency( $vatToApply, $symbolCode, false ) : '--';
-		$vatRateDisp = $vatRate * 100; // Se mantiene el original para display
+		$vatRateDisp = $vatRate * 100; 
 
 		$apaPercDisplay = ( $apaToApply > 0 ) ? formatCurrency( $apaToApply, $symbolCode, false ) : '--';
-		$apaRateDisp    = $apaPercentage * 100; // Se mantiene el original para display
+		$apaRateDisp    = $apaPercentage * 100; 
 
-		// 12) Extras
+		
 		$extrasArr   = array();
 		$extrasTotal = 0;
 		if ( ! empty( $extras ) ) {
@@ -341,15 +296,15 @@ function calculate( array $data ): array {
 			}
 		}
 
-		// 13) Grand total
+		
 		$grandTotalVal  = $subtotal + $extrasTotal;
 		$grandTotalDisp = ( ! empty( $extrasArr ) )
 							? formatCurrency( $grandTotalVal, $symbolCode, true )
 							: null;
 
-		// 14) Gratuity:
-		// Si es EUR => 10% - 15%.
-		// Caso contrario => 15% - 20%.
+		
+		
+		
 		if ( $symbolCode === 'EUR' ) {
 			$gRate1 = 10;
 			$gRate2 = 15;
@@ -371,20 +326,20 @@ function calculate( array $data ): array {
 			),
 		);
 
-		// 15) Armar el bloque final
+		
 		$structuredResults[] = array(
 			'nights'                => ( $hours > 0 ) ? '--' : (string) $nights,
 			'hours'                 => ( $hours > 0 ) ? (string) $hours : '--',
 			'guests'                => (string) $guests,
 			'calculatedBaseRate'    => formatCurrency( $calculatedBaseRate, $symbolCode, true ),
-			'enableExpenses'        => $enableExpenses, // Añadir el flag enableExpenses al array de resultados
+			'enableExpenses'        => $enableExpenses, 
 
 			'discountType'          => $discountType,
-			'discountAmount'        => $discountAmountForDisplay, // Muestra el % o el valor fijo formateado
-			'discountValue'         => $discountValueDisplay, // Muestra el valor calculado del descuento (si aplica)
+			'discountAmount'        => $discountAmountForDisplay, 
+			'discountValue'         => $discountValueDisplay, 
 			'discountedRate'        => ( $discountedRate !== $calculatedBaseRate && $discountedRate >= 0 )
 								   ? formatCurrency( $discountedRate, $symbolCode, true )
-								   : '--', // Mostrar solo si hubo descuento efectivo
+								   : '--', 
 
 			'promotionActive'       => $promotionActive ? '1' : '0',
 			'promotionNights'       => (string) $promotionNights,
@@ -408,30 +363,14 @@ function calculate( array $data ): array {
 			'grandTotal'            => $grandTotalDisp,
 			'gratuityRates'         => $gratuities,
 			
-			'symbolCode'            => $symbolCode, // Add symbolCode to the block
+			'symbolCode'            => $symbolCode, 
 		);
 	}
 
 	return $structuredResults;
 }
 
-/**
- * Formats the calculation results into an array of plain text strings.
- *
- * Takes the structured array produced by `calculate()` and converts it into
- * human-readable text blocks, respecting the user's preferences for hiding
- * certain elements.
- *
- * @since 1.0.0
- *
- * @param array $calcArray    The structured array of calculation results from `calculate()`.
- * @param array $hideElements An associative array indicating which elements should be hidden
- *                            (e.g., `['hideVAT' => true, 'hideAPA' => false]`).
- * @param bool  $enableExpenses Whether expenses are enabled for display.
- *
- * @return array<int, string> An array of strings, where each string is a fully formatted text block
- *                            representing a single charter calculation scenario, ready for display.
- */
+
 function textResult( array $calcArray, array $hideElements = array(), bool $enableExpenses = false, bool $enableMixedSeasons = false ): array {
 	$textBlocks = array();
 
@@ -441,7 +380,7 @@ function textResult( array $calcArray, array $hideElements = array(), bool $enab
 
 		
 
-		// Hours vs nights (imprime siempre)
+		
 		if ( ! empty( $block['hours'] ) && $block['hours'] !== '--' ) {
 			$str .= '<b>' . $block['hours'] . ' hours, ' . $block['guests'] . ' Guests: ' . $block['calculatedBaseRate'];
 			if ( $enableExpenses ) {
@@ -456,7 +395,7 @@ function textResult( array $calcArray, array $hideElements = array(), bool $enab
 			$str .= "</b>\n";
 		}
 
-		// Descuento
+		
 		if (
 			! empty( $block['discountType'] ) &&
 			$block['discountType'] !== '' &&
@@ -470,14 +409,14 @@ function textResult( array $calcArray, array $hideElements = array(), bool $enab
 			$str          .= "Discount Rate - {$discountLabel} = {$block['discountedRate']}\n";
 		}
 
-		// Promoción
+		
 		if ( $block['promotedRate'] !== '--' ) {
 			$str .= 'Promotion Rate ' . $block['promotionNights'] . 'x' . $block['nights'] . ' = ' . $block['promotedRate'] . "\n";
 		}
 
 		$str .= $separator;
 
-		// Impuestos y tasas
+		
 		$taxStr = '';
 
 		if ( ! empty( $block['mixed_breakdown'] ) ) {
@@ -492,7 +431,7 @@ function textResult( array $calcArray, array $hideElements = array(), bool $enab
 			}
 		}
 
-		// Siempre agregar impuestos globales
+		
 		if ( ! $hideElements['hideAPA'] ) {
 			if ( $block['apaPercDisplay'] !== '--' && (float) str_replace( array( '€', '$', ',', ' ' ), '', $block['apaPercDisplay'] ) > 0 ) {
 				$taxStr .= "APA ({$block['apaRateForDisplay']}%): {$block['apaPercDisplay']}\n";
@@ -512,11 +451,11 @@ function textResult( array $calcArray, array $hideElements = array(), bool $enab
 			$str .= $taxStr . $separator;
 		}
 
-		// Subtotal
+		
 		$str .= "<b>Subtotal for charter: {$block['subtotal']}</b>\n";
 		$str .= $separator;
 
-		// Extras
+		
 		if ( ! $hideElements['hideExtras'] && ! empty( $block['extras'] ) ) {
 			$str .= "<b>Extras</b>\n";
 			$str .= $separator;
@@ -528,7 +467,7 @@ function textResult( array $calcArray, array $hideElements = array(), bool $enab
 			$str .= $separator;
 		}
 
-		// Propinas
+		
 		if ( ! $hideElements['hideGratuity'] && ! empty( $block['gratuityRates'] ) ) {
 			foreach ( $block['gratuityRates'] as $gratuity ) {
 				$str .= "Suggested gratuity ({$gratuity['rate']}%): {$gratuity['amount']}\n";

--- a/app_yacht/modules/calc/php/calculatemix.php
+++ b/app_yacht/modules/calc/php/calculatemix.php
@@ -1,18 +1,18 @@
 <?php
-// ARCHIVO modules\calc\php\calculatemix.php
 
-// Registrar las acciones AJAX para usuarios autenticados y no autenticados
+
+
 add_action( 'wp_ajax_calculate_mix', 'handle_calculate_mix' );
 add_action( 'wp_ajax_nopriv_calculate_mix', 'handle_calculate_mix' );
 
 function handle_calculate_mix() {
-	// 1) Verificar nonce para seguridad
+	
 	if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'mix_calculate_nonce' ) ) {
 		wp_send_json_error( array( 'error' => 'Nonce inválido.' ), 400 );
 		return;
 	}
 	
-	// Leer los datos enviados desde el cliente
+	
 	$data = $_POST;
 
 	if ( ! isset( $data['mixnights'], $data['lowSeasonRate'], $data['lowSeasonNights'], $data['highSeasonRate'], $data['highSeasonNights'], $data['currency'] ) ) {
@@ -20,7 +20,7 @@ function handle_calculate_mix() {
 		return;
 	}
 
-	// Convertir a float
+	
 	$mixNights        = (float) str_replace( ',', '', $data['mixnights'] );
 	$lowSeasonRate    = (float) str_replace( ',', '', $data['lowSeasonRate'] );
 	$lowSeasonNights  = (float) str_replace( ',', '', $data['lowSeasonNights'] );
@@ -33,7 +33,7 @@ function handle_calculate_mix() {
 		return;
 	}
 
-	// Calcular
+	
 	$lowSeasonRatePerNight  = $lowSeasonRate / ( $mixNights <= 5 ? 6 : 7 );
 	$lowSeasonTotal         = $lowSeasonRatePerNight * $lowSeasonNights;
 	$highSeasonRatePerNight = $highSeasonRate / ( $mixNights <= 5 ? 6 : 7 );

--- a/app_yacht/modules/mail/mail-service.php
+++ b/app_yacht/modules/mail/mail-service.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Servicio de correo para App_Yacht
- * Maneja envío de emails, integración con Outlook y gestión de firmas
- * 
- * @package AppYacht\Modules\Mail
- * @version 2.0.0
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -13,58 +7,42 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/../../shared/helpers/validator-helper.php';
 
-/**
- * Servicio para gestión de correo electrónico
- */
+
 class MailService implements MailServiceInterface {
 	
-	/**
-	 * @var array Configuración del servicio
-	 */
+	
 	private $config;
 	
-	/**
-	 * @var RenderEngineInterface Motor de renderizado
-	 */
+	
 	private $renderEngine;
 	
-	/**
-	 * Constructor
-	 * 
-	 * @param array                 $config Configuración de mail
-	 * @param RenderEngineInterface $renderEngine Motor de renderizado
-	 */
+	
 	public function __construct( array $config, RenderEngineInterface $renderEngine ) {
 		$this->config       = $config;
 		$this->renderEngine = $renderEngine;
 	}
 	
-	/**
-	 * Envía un email
-	 * 
-	 * @param array $data Datos del email (to, subject, message, etc.)
-	 * @return bool|WP_Error True si se envió, WP_Error si falló
-	 */
+	
 	public function sendEmail( array $data ) {
 		try {
-			// Validar datos del email
+			
 			$validation = $this->validateEmailData( $data );
 			if ( is_wp_error( $validation ) ) {
 				return $validation;
 			}
 			
-			// Sanitizar datos
+			
 			$data = ValidatorHelper::sanitizeInputData( $data );
 			
-			// Determinar método de envío
+			
 			$userId = get_current_user_id();
 			
-			// Si está conectado a Outlook y está habilitado, usar Outlook
+			
 			if ( $this->config['outlook_enabled'] && $this->isOutlookConnected( $userId ) ) {
 				return $this->sendEmailViaOutlook( $data, $userId );
 			}
 			
-			// Usar wp_mail como fallback
+			
 			return $this->sendEmailViaWordPress( $data );
 			
 		} catch ( Exception $e ) {
@@ -73,31 +51,25 @@ class MailService implements MailServiceInterface {
 		}
 	}
 	
-	/**
-	 * Envía email usando Outlook
-	 * 
-	 * @param array $data Datos del email
-	 * @param int   $userId ID del usuario
-	 * @return bool|WP_Error
-	 */
+	
 	public function sendEmailViaOutlook( array $data, $userId ) {
 		try {
-			// Verificar si las funciones de Outlook están disponibles
+			
 			if ( ! function_exists( 'pb_outlook_send_mail' ) ) {
 				return new WP_Error( 'outlook_not_available', 'Funciones de Outlook no disponibles' );
 			}
 			
-			// Preparar datos para Outlook
+			
 			$outlookData = $this->prepareOutlookData( $data, $userId );
 			
-			// Enviar usando la función existente de Outlook
+			
 			$result = pb_outlook_send_mail( $outlookData, $userId );
 			
 			if ( is_wp_error( $result ) ) {
-				// Log del error para debugging
+				
 				error_log( 'Outlook Send Error: ' . $result->get_error_message() );
 				
-				// Intentar fallback a wp_mail si está configurado
+				
 				if ( $this->config['fallback_to_wp_mail'] ?? true ) {
 					return $this->sendEmailViaWordPress( $data );
 				}
@@ -113,48 +85,34 @@ class MailService implements MailServiceInterface {
 		}
 	}
 	
-	/**
-	 * Verifica si un usuario está conectado a Outlook
-	 * 
-	 * @param int $userId ID del usuario
-	 * @return bool
-	 */
+	
 	public function isOutlookConnected( $userId ) {
 		if ( function_exists( 'pb_outlook_is_connected' ) ) {
 			return pb_outlook_is_connected( $userId );
 		}
 		
-		// Fallback: verificar si existen tokens en user_meta
+		
 		$accessToken = get_user_meta( $userId, 'outlook_access_token', true );
 		return ! empty( $accessToken );
 	}
 	
-	/**
-	 * Obtiene la URL de autenticación para Outlook
-	 * 
-	 * @return string URL de login
-	 */
+	
 	public function getOutlookLoginUrl() {
 		if ( function_exists( 'pb_outlook_get_login_url' ) ) {
 			return pb_outlook_get_login_url();
 		}
 		
-		return '#'; // Fallback
+		return '#'; 
 	}
 	
-	/**
-	 * Desconecta la cuenta de Outlook de un usuario
-	 * 
-	 * @param int $userId ID del usuario
-	 * @return bool
-	 */
+	
 	public function disconnectOutlook( $userId ) {
 		try {
 			if ( function_exists( 'pb_outlook_disconnect_user' ) ) {
 				return pb_outlook_disconnect_user( $userId );
 			}
 			
-			// Fallback: eliminar tokens manualmente
+			
 			delete_user_meta( $userId, 'outlook_access_token' );
 			delete_user_meta( $userId, 'outlook_refresh_token' );
 			delete_user_meta( $userId, 'outlook_email' );
@@ -168,18 +126,13 @@ class MailService implements MailServiceInterface {
 		}
 	}
 	
-	/**
-	 * Valida los datos de un email
-	 * 
-	 * @param array $data Datos a validar
-	 * @return bool|WP_Error
-	 */
+	
 	public function validateEmailData( array $data ) {
 		$errors = ValidatorHelper::validateEmailData( $data );
 		
-		// Validaciones adicionales específicas del servicio
 		
-		// Verificar límite de destinatarios
+		
+		
 		if ( isset( $data['to'] ) ) {
 			$recipients = explode( ',', $data['to'] );
 			if ( count( $recipients ) > $this->config['max_recipients'] ) {
@@ -187,7 +140,7 @@ class MailService implements MailServiceInterface {
 			}
 		}
 		
-		// Validar archivos adjuntos si existen
+		
 		if ( isset( $data['attachments'] ) && ! empty( $data['attachments'] ) ) {
 			$attachmentValidation = $this->validateAttachments( $data['attachments'] );
 			if ( is_wp_error( $attachmentValidation ) ) {
@@ -202,22 +155,17 @@ class MailService implements MailServiceInterface {
 		return true;
 	}
 	
-	/**
-	 * Procesa archivos adjuntos
-	 * 
-	 * @param array $attachments Archivos adjuntos
-	 * @return array|WP_Error Archivos procesados o error
-	 */
+	
 	public function processAttachments( array $attachments ) {
 		$processed = array();
 		
 		foreach ( $attachments as $attachment ) {
-			// Validar tamaño
+			
 			if ( $attachment['size'] > $this->config['attachment_max_size'] ) {
 				return new WP_Error( 'attachment_too_large', 'Archivo muy grande: ' . $attachment['name'] );
 			}
 			
-			// Validar tipo
+			
 			$extension = pathinfo( $attachment['name'], PATHINFO_EXTENSION );
 			if ( ! in_array( strtolower( $extension ), $this->config['allowed_attachment_types'] ) ) {
 				return new WP_Error( 'attachment_type_not_allowed', 'Tipo de archivo no permitido: ' . $extension );
@@ -229,24 +177,19 @@ class MailService implements MailServiceInterface {
 		return $processed;
 	}
 	
-	/**
-	 * Genera firma de email
-	 * 
-	 * @param int $userId ID del usuario
-	 * @return string HTML de la firma
-	 */
+	
 	public function generateSignature( $userId ) {
 		if ( ! $this->config['signature_enabled'] ) {
 			return '';
 		}
 		
-		// Intentar obtener firma personalizada del usuario
+		
 		$customSignature = get_user_meta( $userId, 'yacht_email_signature', true );
 		if ( ! empty( $customSignature ) ) {
 			return $customSignature;
 		}
 		
-		// Generar firma por defecto
+		
 		$user = get_user_by( 'id', $userId );
 		if ( ! $user ) {
 			return '';
@@ -266,9 +209,7 @@ class MailService implements MailServiceInterface {
 		return $signature;
 	}
 	
-	/**
-	 * Envía email usando wp_mail de WordPress
-	 */
+	
 	private function sendEmailViaWordPress( array $data ) {
 		try {
 			$to          = $this->parseEmailRecipients( $data['to'] );
@@ -291,9 +232,7 @@ class MailService implements MailServiceInterface {
 		}
 	}
 	
-	/**
-	 * Prepara datos para envío con Outlook
-	 */
+	
 	private function prepareOutlookData( array $data, $userId ) {
 		$outlookData = array(
 			'to'      => $data['to'],
@@ -302,17 +241,17 @@ class MailService implements MailServiceInterface {
 			'is_html' => true,
 		);
 		
-		// Agregar CC si existe
+		
 		if ( ! empty( $data['cc'] ) ) {
 			$outlookData['cc'] = $data['cc'];
 		}
 		
-		// Agregar BCC si existe
+		
 		if ( ! empty( $data['bcc'] ) ) {
 			$outlookData['bcc'] = $data['bcc'];
 		}
 		
-		// Agregar archivos adjuntos
+		
 		if ( ! empty( $data['attachments'] ) ) {
 			$outlookData['attachments'] = $this->processAttachments( $data['attachments'] );
 		}
@@ -320,13 +259,11 @@ class MailService implements MailServiceInterface {
 		return $outlookData;
 	}
 	
-	/**
-	 * Prepara el contenido del email
-	 */
+	
 	private function prepareEmailContent( array $data ) {
 		$content = $data['message'];
 		
-		// Agregar firma si está habilitado
+		
 		if ( $this->config['signature_enabled'] ) {
 			$userId    = get_current_user_id();
 			$signature = $this->generateSignature( $userId );
@@ -339,33 +276,31 @@ class MailService implements MailServiceInterface {
 		return $content;
 	}
 	
-	/**
-	 * Prepara headers para wp_mail
-	 */
+	
 	private function prepareEmailHeaders( array $data ) {
 		$headers = array();
 		
-		// Content-Type
+		
 		$headers[] = 'Content-Type: text/html; charset=UTF-8';
 		
-		// From
+		
 		if ( ! empty( $data['from'] ) ) {
 			$headers[] = 'From: ' . $data['from'];
 		} else {
 			$headers[] = 'From: ' . $this->config['default_sender'];
 		}
 		
-		// Reply-To
+		
 		if ( ! empty( $data['reply_to'] ) ) {
 			$headers[] = 'Reply-To: ' . $data['reply_to'];
 		}
 		
-		// CC
+		
 		if ( ! empty( $data['cc'] ) ) {
 			$headers[] = 'Cc: ' . $data['cc'];
 		}
 		
-		// BCC
+		
 		if ( ! empty( $data['bcc'] ) ) {
 			$headers[] = 'Bcc: ' . $data['bcc'];
 		}
@@ -373,9 +308,7 @@ class MailService implements MailServiceInterface {
 		return $headers;
 	}
 	
-	/**
-	 * Prepara archivos adjuntos para wp_mail
-	 */
+	
 	private function prepareAttachments( array $data ) {
 		if ( empty( $data['attachments'] ) ) {
 			return array();
@@ -392,9 +325,7 @@ class MailService implements MailServiceInterface {
 		return $attachments;
 	}
 	
-	/**
-	 * Parsea destinatarios de email
-	 */
+	
 	private function parseEmailRecipients( $to ) {
 		if ( is_string( $to ) ) {
 			return array_map( 'trim', explode( ',', $to ) );
@@ -403,22 +334,20 @@ class MailService implements MailServiceInterface {
 		return is_array( $to ) ? $to : array( $to );
 	}
 	
-	/**
-	 * Valida archivos adjuntos
-	 */
+	
 	private function validateAttachments( array $attachments ) {
 		foreach ( $attachments as $attachment ) {
-			// Validar estructura
+			
 			if ( ! isset( $attachment['name'] ) || ! isset( $attachment['size'] ) ) {
 				return new WP_Error( 'invalid_attachment', 'Estructura de archivo adjunto inválida' );
 			}
 			
-			// Validar tamaño
+			
 			if ( $attachment['size'] > $this->config['attachment_max_size'] ) {
 				return new WP_Error( 'attachment_too_large', 'Archivo muy grande: ' . $attachment['name'] );
 			}
 			
-			// Validar extensión
+			
 			$extension = pathinfo( $attachment['name'], PATHINFO_EXTENSION );
 			if ( ! in_array( strtolower( $extension ), $this->config['allowed_attachment_types'] ) ) {
 				return new WP_Error( 'attachment_type_not_allowed', 'Tipo no permitido: ' . $extension );

--- a/app_yacht/modules/mail/mail.php
+++ b/app_yacht/modules/mail/mail.php
@@ -1,20 +1,20 @@
 <?php
-// Archivo modules\mail\mail.php
 
-// Incluir funciones de firma
+
+
 require_once get_template_directory() . '/app_yacht/modules/mail/signature/signature-functions.php';
 
-// Cargar todas las funciones de Outlook a través del cargador centralizado
+
 require_once get_template_directory() . '/app_yacht/modules/mail/outlook/outlook-loader.php';
 
-// Generar la URL para autenticar en Outlook
+
 $login_url = function_exists( 'pb_outlook_get_login_url' ) ? pb_outlook_get_login_url() : '#';
 
-// Chequear si el usuario tiene un email de Outlook en user_meta
+
 $user_email = get_user_meta( get_current_user_id(), 'outlook_email', true );
 $user_email = ! empty( $user_email ) ? esc_html( $user_email ) : '';
 
-// Verificar si el usuario está conectado a Outlook
+
 $is_connected = function_exists( 'pb_outlook_is_connected' ) ? pb_outlook_is_connected( get_current_user_id() ) : false;
 ?>
 <div class="container mail-container">
@@ -134,9 +134,9 @@ $is_connected = function_exists( 'pb_outlook_is_connected' ) ? pb_outlook_is_con
 				</div>
 				<div class="col-12">
 					<?php 
-					// Llamar al shortcode [outlook_signature]
-					// Esto requiere que el plugin "Mail Signature Pro" (o como lo hayas llamado) esté activo.
-					// De ese modo, do_shortcode('[outlook_signature]') ejecuta el contenido definido en el plugin.
+					
+					
+					
 					echo do_shortcode( '[outlook_signature]' );
 					?>
 				</div>

--- a/app_yacht/modules/mail/outlook/outlook-form.php
+++ b/app_yacht/modules/mail/outlook/outlook-form.php
@@ -1,18 +1,18 @@
 <?php
-// Archivo app_yacht\modules\mail\outlook\outlook-form.php
+
 
 if ( ! is_user_logged_in() ) {
 	echo '<p>You must be logged into WordPress before connecting your Outlook account.</p>';
 	return;
 }
 
-// Verify if the function exists before calling it
+
 if ( ! function_exists( 'pb_outlook_get_login_url' ) ) {
 	echo '<p style="color:red;">Error: The function pb_outlook_get_login_url is not available.</p>';
 	return;
 }
 
-// Get the Outlook authentication URL
+
 $login_url = pb_outlook_get_login_url();
 
 if ( empty( $login_url ) ) {
@@ -27,7 +27,7 @@ if ( empty( $login_url ) ) {
 	<?php
 }
 
-// Display success message when redirected after successful authentication
+
 if ( isset( $_GET['outlook'] ) && $_GET['outlook'] === 'success' ) {
 	$user_email    = get_user_meta( get_current_user_id(), 'outlook_email', true );
 	$email_display = ! empty( $user_email ) ? '<strong>' . esc_html( $user_email ) . '</strong>' : 'Outlook';

--- a/app_yacht/modules/mail/outlook/outlook-functions.php
+++ b/app_yacht/modules/mail/outlook/outlook-functions.php
@@ -1,27 +1,22 @@
 <?php
 
-/**
- * outlook-functions.php
- * Lógica de OAuth y envío de correos vía Microsoft Graph.
- */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Las dependencias (security.php, utils.php) son cargadas globalmente
-// por core/yacht-functions.php.
 
-// Ajusta las credenciales directamente
-// Ajusta las credenciales directamente
+
+
+
+
 define('PB_OUTLOOK_CLIENT_ID', '730ac41d-30c8-446c-b6bc-9470d539fdee');
 define('PB_OUTLOOK_CLIENT_SECRET', '.ii8Q~GeEeqre-rBd568TNxt.oOEiREv9_XzLdeB');
 
 define('PB_OUTLOOK_REDIRECT_URI', 'https://www.probroke.com/appyacht/auth');
 define('PB_OUTLOOK_SCOPES', 'openid profile offline_access User.Read Mail.Send');
 
-/**
- * Genera la URL para iniciar el proceso OAuth con Microsoft
- */
+
 function pb_outlook_get_login_url() {
 	$base_url = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize';
 	$params   = array(
@@ -33,12 +28,10 @@ function pb_outlook_get_login_url() {
 	return $base_url . '?' . http_build_query( $params );
 }
 
-/**
- * Intercambiar "code" por tokens
- */
+
 function pb_outlook_exchange_code_for_tokens( $code ) {
-	// wp_die("DEBUG: Entering pb_outlook_exchange_code_for_tokens"); // Descomentar para probar
-	// Registrar evento
+	
+	
 	pb_log_security_event(
 		get_current_user_id(),
 		'oauth_token_exchange',
@@ -71,7 +64,7 @@ function pb_outlook_exchange_code_for_tokens( $code ) {
 		return new WP_Error( 'token_error', $data['error_description'] ?? 'Error al obtener tokens' );
 	}
 
-	// Registrar evento
+	
 	pb_log_security_event(
 		get_current_user_id(),
 		'oauth_token_exchange',
@@ -84,16 +77,14 @@ function pb_outlook_exchange_code_for_tokens( $code ) {
 	return $data;
 }
 
-/**
- * Guardar tokens en user_meta
- */
+
 function pb_outlook_save_tokens_to_user( $user_id, $tokens ) {
-	// wp_die("DEBUG: Entering pb_outlook_save_tokens_to_user"); // Descomentar para probar
+	
 	$access_token  = $tokens['access_token'] ?? '';
 	$refresh_token = $tokens['refresh_token'] ?? '';
 	$expires_in    = isset( $tokens['expires_in'] ) ? time() + (int) $tokens['expires_in'] : 0;
 
-	// Encriptar tokens usando la función centralizada
+	
 	$encrypted_access_token  = pb_encrypt_data( $access_token );
 	$encrypted_refresh_token = pb_encrypt_data( $refresh_token );
 
@@ -101,10 +92,10 @@ function pb_outlook_save_tokens_to_user( $user_id, $tokens ) {
 	update_user_meta( $user_id, 'outlook_refresh_token', $encrypted_refresh_token );
 	update_user_meta( $user_id, 'outlook_expires_at', $expires_in );
 
-	// Registrar evento
+	
 	pb_log_security_event( $user_id, 'oauth_tokens_saved' );
 
-	// Si hay id_token, extraer correo preferido
+	
 	if ( ! empty( $tokens['id_token'] ) ) {
 		$parts = explode( '.', $tokens['id_token'] );
 		if ( count( $parts ) === 3 ) {
@@ -116,9 +107,7 @@ function pb_outlook_save_tokens_to_user( $user_id, $tokens ) {
 	}
 }
 
-/**
- * Obtener (y refrescar si es necesario) el access_token
- */
+
 function pb_outlook_get_user_access_token( $user_id ) {
 	$encrypted_access_token  = get_user_meta( $user_id, 'outlook_access_token', true );
 	$encrypted_refresh_token = get_user_meta( $user_id, 'outlook_refresh_token', true );
@@ -128,15 +117,15 @@ function pb_outlook_get_user_access_token( $user_id ) {
 		return new WP_Error( 'missing_tokens', 'El usuario no tiene tokens de Outlook.' );
 	}
 
-	// Desencriptar tokens usando la función centralizada
+	
 	$access_token  = pb_decrypt_data( $encrypted_access_token );
 	$refresh_token = pb_decrypt_data( $encrypted_refresh_token );
 
-	// Verificar si los tokens existen después de desencriptar
+	
 	if ( ! $access_token || ! $refresh_token ) {
 		return new WP_Error( 'missing_tokens', 'El usuario no tiene tokens de Outlook.' );
 	}
-	// Refrescar si expiró
+	
 	if ( time() >= $expires_at ) {
 		$new_tokens = pb_outlook_refresh_token( $refresh_token );
 		if ( is_wp_error( $new_tokens ) ) {
@@ -148,9 +137,7 @@ function pb_outlook_get_user_access_token( $user_id ) {
 	return $access_token;
 }
 
-/**
- * Refrescar token
- */
+
 function pb_outlook_refresh_token( $refresh_token ) {
 	$url      = 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
 	$params   = array(
@@ -176,39 +163,29 @@ function pb_outlook_refresh_token( $refresh_token ) {
 	return $data;
 }
 
-/**
- * Enviar correo con Microsoft Graph en nombre del user_id
- *
- * @param int          $user_id ID del usuario de WordPress
- * @param string|array $to Destinatario(s) principal(es), puede ser una dirección o múltiples separadas por comas
- * @param string       $subject Asunto del correo
- * @param string       $body_content Contenido HTML del correo
- * @param string|array $cc Destinatario(s) en copia, puede ser una dirección o múltiples separadas por comas
- * @param string|array $bcc Destinatario(s) en copia oculta, puede ser una dirección o múltiples separadas por comas
- * @return bool|WP_Error True si se envió correctamente, WP_Error en caso de error
- */
+
 function pb_outlook_send_mail_on_behalf( $user_id, $to, $subject, $body_content, $cc = '', $bcc = '' ) {
-	// Verificar que estamos en HTTPS
+	
 	if ( ! is_ssl() && ! WP_DEBUG ) {
 		 return new WP_Error( 'insecure_connection', 'Esta operación requiere una conexión segura (HTTPS).' );
 	}
 
-	 // error_log("pb_outlook_send_mail_on_behalf: Iniciando envío para user $user_id"); // DEBUG REMOVED
-	 // 1) Obtener access_token
+	 
+	 
 	 $access_token = pb_outlook_get_user_access_token( $user_id );
 	if ( is_wp_error( $access_token ) ) {
-		// error_log("pb_outlook_send_mail_on_behalf: Error obteniendo token: " . $access_token->get_error_message()); // DEBUG REMOVED
+		
 		return $access_token;
 	}
 	if ( empty( $access_token ) ) { 
-		 // error_log("pb_outlook_send_mail_on_behalf: Token vacío obtenido para user $user_id"); // DEBUG REMOVED
+		 
 		 return new WP_Error( 'token_error', 'No se pudo obtener un token de acceso válido.' );
 	}
 
-	// 2) Sanitizar HTML usando la función centralizada
+	
 	$clean_body = pb_sanitize_html_content( $body_content );
 
-	// 3) Envolver en DOCTYPE + HTML
+	
 	$wrapped_html = '<!DOCTYPE html>
 <html>
 <head>
@@ -220,8 +197,8 @@ function pb_outlook_send_mail_on_behalf( $user_id, $to, $subject, $body_content,
 </body>
  </html>';
 
-	 // error_log("pb_outlook_send_mail_on_behalf: Token obtenido, preparando cuerpo..."); // DEBUG REMOVED
-	 // 4) Llamar a Microsoft Graph
+	 
+	 
 	 $sendMailUrl = 'https://graph.microsoft.com/v1.0/me/sendMail';
 	$requestBody  = array(
 		'message' => array(
@@ -234,7 +211,7 @@ function pb_outlook_send_mail_on_behalf( $user_id, $to, $subject, $body_content,
 		),
 	);
 
-	// Procesar destinatarios principales (TO)
+	
 	if ( is_string( $to ) && strpos( $to, ',' ) !== false ) {
 		$to_array = array_map( 'trim', explode( ',', $to ) );
 	} else {
@@ -242,15 +219,15 @@ function pb_outlook_send_mail_on_behalf( $user_id, $to, $subject, $body_content,
 	}
 	
 	foreach ( $to_array as $email ) {
-		$sanitized_email = sanitize_email( trim( $email ) ); // Trim whitespace first
-		if ( ! empty( $sanitized_email ) && is_email( $sanitized_email ) ) { // Add is_email check
+		$sanitized_email = sanitize_email( trim( $email ) ); 
+		if ( ! empty( $sanitized_email ) && is_email( $sanitized_email ) ) { 
 			$requestBody['message']['toRecipients'][] = array(
 				'emailAddress' => array( 'address' => $sanitized_email ),
 			);
 		}
 	}
 
-	// Procesar destinatarios en copia (CC)
+	
 	if ( ! empty( $cc ) ) {
 		$cc_array = is_string( $cc ) && strpos( $cc, ',' ) !== false ?
 			array_map( 'trim', explode( ',', $cc ) ) :
@@ -271,7 +248,7 @@ function pb_outlook_send_mail_on_behalf( $user_id, $to, $subject, $body_content,
 		}
 	}
 
-	// Procesar destinatarios en copia oculta (BCC)
+	
 	if ( ! empty( $bcc ) ) {
 		$bcc_array = is_string( $bcc ) && strpos( $bcc, ',' ) !== false ?
 			array_map( 'trim', explode( ',', $bcc ) ) :
@@ -301,20 +278,20 @@ function pb_outlook_send_mail_on_behalf( $user_id, $to, $subject, $body_content,
 			),
 			'body'       => json_encode( $requestBody ),
 			'timeout'    => 30,
-			'sslverify'  => true, // Forzar verificación SSL
+			'sslverify'  => true, 
 		)
 	);
 
-	 // error_log("pb_outlook_send_mail_on_behalf: Respuesta de wp_remote_post: " . print_r($response, true)); // DEBUG REMOVED
+	 
 
 	if ( is_wp_error( $response ) ) {
-		// Registrar el error para análisis
-		error_log( 'pb_outlook_send_mail_on_behalf: Error en wp_remote_post: ' . $response->get_error_message() ); // Log real
+		
+		error_log( 'pb_outlook_send_mail_on_behalf: Error en wp_remote_post: ' . $response->get_error_message() ); 
 		return new WP_Error( 'send_mail_failed', $response->get_error_message() );
 	}
 	$status_code = wp_remote_retrieve_response_code( $response );
 	if ( $status_code >= 200 && $status_code < 300 ) {
-		// Registrar evento
+		
 		pb_log_security_event(
 			$user_id,
 			'email_sent',
@@ -325,7 +302,7 @@ function pb_outlook_send_mail_on_behalf( $user_id, $to, $subject, $body_content,
 		);
 		return true;
 	}
-	// Registrar el error para análisis
+	
 	error_log( 'Error al enviar correo. Respuesta HTTP: ' . $status_code . ' => ' . wp_remote_retrieve_body( $response ) );
 	return new WP_Error(
 		'send_mail_error',
@@ -333,28 +310,20 @@ function pb_outlook_send_mail_on_behalf( $user_id, $to, $subject, $body_content,
 	);
 }
 
-/**
- * Verifica si el usuario tiene tokens de Outlook válidos
- *
- * @param int $user_id ID del usuario de WordPress
- * @return bool True si el usuario está conectado, false en caso contrario
- */
+
 function pb_outlook_is_connected( $user_id ) {
-	// Implementación centralizada
+	
 	$encrypted_access_token  = get_user_meta( $user_id, 'outlook_access_token', true );
 	$encrypted_refresh_token = get_user_meta( $user_id, 'outlook_refresh_token', true );
 	
 	return ( ! empty( $encrypted_access_token ) && ! empty( $encrypted_refresh_token ) );
 }
 
-// La lógica para manejar el callback de autenticación (?code=...) se ha movido a core/yacht-functions.php
 
-/**
- * Handler AJAX: pb_outlook_send_mail
- * (AQUÍ concatenamos la firma guardada con meta_key "msp_signature")
- */
+
+
 function pb_outlook_send_mail_ajax_handler() {
-	// Verificar límite de intentos
+	
 	$user_id   = get_current_user_id();
 	$limit_key = 'mail_send_' . $user_id;
 
@@ -363,16 +332,16 @@ function pb_outlook_send_mail_ajax_handler() {
 		 return;
 	}
 	 check_ajax_referer( 'pb_outlook_nonce', 'nonce' ); 
-	 // error_log("pb_outlook_send_mail_ajax_handler: Nonce check bypassed for debugging."); // DEBUG REMOVED
+	 
 
 	if ( ! is_user_logged_in() ) {
 		wp_send_json_error( 'No estás autenticado en WordPress.', 401 );
 	}
 	$user_id = get_current_user_id();
 	
-	// Verificar si el usuario tiene la capacidad para enviar correos
+	
 	if ( ! pb_verify_user_capability( 'send_yacht_emails', 'No tienes permisos para enviar correos.' ) ) {
-		return; // La función pb_verify_user_capability ya envía la respuesta de error
+		return; 
 	}
 
 	$to      = $_POST['to'] ?? '';
@@ -385,38 +354,31 @@ function pb_outlook_send_mail_ajax_handler() {
 		wp_send_json_error( 'Faltan campos obligatorios.', 400 );
 	}
 
-	// 1) Recuperamos la firma del plugin "Mail Signature Pro" (meta_key = msp_signature):
+	
 	$signature = get_user_meta( $user_id, 'msp_signature', true );
 	if ( ! empty( $signature ) ) {
 		 $body .= '<br><br>' . $signature;
 	}
 
-	 // error_log("pb_outlook_send_mail_ajax_handler: Llamando a pb_outlook_send_mail_on_behalf..."); // DEBUG REMOVED
-	 // 2) Enviar
+	 
+	 
 	 $result = pb_outlook_send_mail_on_behalf( $user_id, $to, $subject, $body, $cc, $bcc );
 	 
-	 // error_log("pb_outlook_send_mail_ajax_handler: Resultado de send_mail_on_behalf: " . print_r($result, true)); // DEBUG REMOVED
+	 
 
 	if ( is_wp_error( $result ) ) {
-		// error_log("pb_outlook_send_mail_ajax_handler: Error detectado: " . $result->get_error_message()); // DEBUG REMOVED
+		
 		wp_send_json_error( $result->get_error_message(), 500 ); 
 	}
 	wp_send_json_success( 'Correo enviado exitosamente.' );
 }
 
-/**
- * Elimina los tokens de Outlook del usuario usando delete_user_meta directamente.
- * Versión refactorizada para usar funciones centralizadas de seguridad y registro.
- * (Ahora centralizada aquí)
- *
- * @param int $user_id ID del usuario de WordPress
- * @return bool True si se eliminaron los tokens correctamente, false en caso contrario
- */
+
 function pb_outlook_disconnect_user( $user_id ) {
 	try {
-		// Verificar que el usuario exista
+		
 		if ( ! get_user_by( 'id', $user_id ) ) {
-			// Usar función centralizada de registro de eventos
+			
 			pb_log_security_event(
 				$user_id,
 				'outlook_disconnect_failed',
@@ -428,10 +390,10 @@ function pb_outlook_disconnect_user( $user_id ) {
 			return false;
 		}
 		
-		// Registrar evento antes de eliminar tokens usando función centralizada
+		
 		pb_log_security_event( $user_id, 'outlook_disconnect_started' );
 		
-		// Lista de meta_keys a eliminar
+		
 		$meta_keys = array(
 			'outlook_access_token',
 			'outlook_refresh_token',
@@ -439,7 +401,7 @@ function pb_outlook_disconnect_user( $user_id ) {
 			'outlook_email',
 		);
 		
-		// Eliminar tokens usando delete_user_meta directamente
+		
 		$success = true;
 		$results = array();
 		
@@ -452,7 +414,7 @@ function pb_outlook_disconnect_user( $user_id ) {
 			}
 		}
 		
-		// Registrar evento de finalización usando función centralizada
+		
 		pb_log_security_event(
 			$user_id,
 			'outlook_disconnect_completed',
@@ -464,7 +426,7 @@ function pb_outlook_disconnect_user( $user_id ) {
 		
 		return $success;
 	} catch ( Exception $e ) {
-		// Registrar excepción usando función centralizada
+		
 		pb_log_security_event(
 			$user_id,
 			'outlook_disconnect_error',
@@ -474,9 +436,9 @@ function pb_outlook_disconnect_user( $user_id ) {
 			)
 		);
 		error_log( 'Excepción en pb_outlook_disconnect_user: ' . $e->getMessage() );
-		return false; // Indicar fallo en la desconexión
+		return false; 
 	} catch ( Throwable $t ) {
-		// Registrar error fatal usando función centralizada
+		
 		pb_log_security_event(
 			$user_id,
 			'outlook_disconnect_error',
@@ -486,30 +448,26 @@ function pb_outlook_disconnect_user( $user_id ) {
 			)
 		);
 		error_log( 'Error fatal en pb_outlook_disconnect_user: ' . $t->getMessage() );
-		return false; // Indicar fallo en la desconexión
+		return false; 
 	}
 }
 
 
-/**
- * Handler AJAX: pb_outlook_disconnect
- * (Movido desde outlook-disconnect.php)
- * Versión refactorizada para usar funciones centralizadas de seguridad y registro
- */
+
 function pb_outlook_disconnect_ajax_handler() {
-	// Capturar cualquier error fatal que pueda ocurrir
+	
 	try {
-		// Registrar inicio del handler usando función centralizada
+		
 		pb_log_security_event( 0, 'outlook_disconnect_ajax_started' );
 		
-		// Verificar nonce de forma simple
+		
 		if ( ! isset( $_POST['nonce'] ) ) {
 			pb_log_security_event( 0, 'outlook_disconnect_ajax_failed', array( 'reason' => 'missing_nonce' ) );
 			wp_send_json_error( 'Error de seguridad: Token no proporcionado. Por favor, recarga la página e intenta de nuevo.', 403 );
 			return;
 		}
 		
-		// Verificar el nonce con wp_verify_nonce directamente
+		
 		$nonce_verification = wp_verify_nonce( $_POST['nonce'], 'pb_outlook_nonce' );
 		if ( ! $nonce_verification ) {
 			pb_log_security_event( 0, 'outlook_disconnect_ajax_failed', array( 'reason' => 'invalid_nonce' ) );
@@ -517,21 +475,21 @@ function pb_outlook_disconnect_ajax_handler() {
 			return;
 		}
 		
-		// Verificar que el usuario esté autenticado
+		
 		if ( ! is_user_logged_in() ) {
 			pb_log_security_event( 0, 'outlook_disconnect_ajax_failed', array( 'reason' => 'not_authenticated' ) );
 			wp_send_json_error( 'Debes iniciar sesión para realizar esta acción.', 401 );
 			return;
 		}
 		
-		// Obtener el ID del usuario actual
+		
 		$user_id = get_current_user_id();
 		
-		// Desconectar al usuario usando la función existente
-		// (Asegurarse de que pb_outlook_disconnect_user esté definida en este archivo o incluida)
+		
+		
 		$result = pb_outlook_disconnect_user( $user_id ); 
 		
-		// Verificar el resultado y enviar respuesta
+		
 		if ( $result ) {
 			pb_log_security_event( $user_id, 'outlook_disconnect_ajax_success' );
 			wp_send_json_success( 'Tu cuenta de Outlook ha sido desconectada correctamente.' );

--- a/app_yacht/modules/mail/outlook/outlook-loader.php
+++ b/app_yacht/modules/mail/outlook/outlook-loader.php
@@ -1,15 +1,12 @@
 <?php
-/**
- * outlook-loader.php
- * Archivo para asegurar que todas las funciones de Outlook estén cargadas correctamente
- */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Cargar funciones principales de Outlook si no están cargadas
+
 if ( ! function_exists( 'pb_outlook_get_login_url' ) ) {
 	require_once get_template_directory() . '/app_yacht/modules/mail/outlook/outlook-functions.php';
 }
 
-// El archivo outlook-disconnect.php ha sido eliminado ya que su contenido fue movido a outlook-functions.php
+

--- a/app_yacht/modules/mail/signature/signature-functions.php
+++ b/app_yacht/modules/mail/signature/signature-functions.php
@@ -1,20 +1,14 @@
 <?php
-/**
- * Mail Signature Functions
- * Integrated from Mail Signature Pro plugin
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * 1) Registrar endpoints AJAX (save_signature, delete_signature)
- *    Cada endpoint verificará un nonce "msp_nonce_action" en la variable "mspNonce".
- */
+
 add_action( 'wp_ajax_msp_save_signature', 'msp_save_signature_callback' );
 function msp_save_signature_callback() {
-	check_ajax_referer( 'msp_nonce_action', 'mspNonce' ); // <-- Verifica nonce
+	check_ajax_referer( 'msp_nonce_action', 'mspNonce' ); 
 
 	if ( ! is_user_logged_in() ) {
 		wp_send_json_error( 'User not logged in', 401 );
@@ -37,32 +31,29 @@ function msp_delete_signature_callback() {
 	wp_send_json_success( 'Signature removed' );
 }
 
-/**
- * 2) Shortcode [outlook_signature]
- *    Imprime el editor de firma y encola el JS con su nonce.
- */
+
 add_shortcode( 'outlook_signature', 'msp_signature_shortcode' );
 function msp_signature_shortcode() {
 	if ( ! is_user_logged_in() ) {
 		return "<p style='color:red;'>Please log in to manage your signature.</p>";
 	}
 
-	// Recuperar la firma
+	
 	$user_id   = get_current_user_id();
 	$signature = get_user_meta( $user_id, 'msp_signature', true );
 	if ( ! $signature ) {
 		$signature = '';
 	}
 
-	// Encolar scripts
+	
 	msp_enqueue_scripts();
 
-	// Devuelve HTML del editor
+	
 	ob_start(); ?>
 	<div class="msp-signature-wrapper" style="border:1px solid #ccc; padding:10px; margin-bottom:10px;">
 		<h3>Signature Editor</h3>
 		<div id="mspEditor" contenteditable="true" style="min-height:100px; border:1px solid #ddd; padding:5px;">
-			<?php echo $signature; // no esc_html para que se renderice ?>
+			<?php echo $signature; ?>
 		</div>
 		<div style="margin-top:10px;">
 			<button type="button" id="mspBtnSave" class="button button-primary">Save Signature</button>
@@ -74,18 +65,16 @@ function msp_signature_shortcode() {
 	return ob_get_clean();
 }
 
-/**
- * 3) Encolar y localizar scripts
- */
+
 function msp_enqueue_scripts() {
-	// Encolamos solo si no está ya encolado
+	
 	static $done = false;
 	if ( $done ) {
-		return; // Evita doble encolado
+		return; 
 	}
 	$done = true;
 
-	// Encolar
+	
 	wp_enqueue_script(
 		'msp-signature-js',
 		get_template_directory_uri() . '/app_yacht/modules/mail/signature/msp-signature.js',
@@ -93,7 +82,7 @@ function msp_enqueue_scripts() {
 		'1.0',
 		true
 	);
-	// Localizar nonce
+	
 	wp_localize_script(
 		'msp-signature-js',
 		'mspData',
@@ -104,9 +93,7 @@ function msp_enqueue_scripts() {
 	);
 }
 
-/**
- * (Opcional) Encolar CSS
- */
+
 add_action( 'wp_enqueue_scripts', 'msp_add_styles' );
 function msp_add_styles() {
 	wp_register_style( 'msp-styles', get_template_directory_uri() . '/app_yacht/modules/mail/signature/msp-styles.css', array(), '1.0', 'all' );

--- a/app_yacht/modules/render/render-engine.php
+++ b/app_yacht/modules/render/render-engine.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Motor de renderizado unificado para App_Yacht
- * Maneja plantillas, generación de contenido y adaptadores de formato
- * 
- * @package AppYacht\Modules\Render
- * @version 2.0.0
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -13,48 +7,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/../../shared/helpers/cache-helper.php';
 
-/**
- * Motor de renderizado para plantillas y contenido
- */
+
 class RenderEngine implements RenderEngineInterface {
 	
-	/**
-	 * @var array Configuración del motor
-	 */
+	
 	private $config;
 	
-	/**
-	 * @var array Adaptadores de formato registrados
-	 */
+	
 	private $formatAdapters;
 	
-	/**
-	 * Constructor
-	 * 
-	 * @param array $config Configuración de templates
-	 */
+	
 	public function __construct( array $config ) {
 		$this->config         = $config;
 		$this->formatAdapters = array();
 		$this->registerDefaultAdapters();
 	}
 	
-	/**
-	 * Renderiza una plantilla con datos
-	 * 
-	 * @param string $template Nombre de la plantilla
-	 * @param array  $data Datos para la plantilla
-	 * @param string $format Formato de salida (html|text)
-	 * @return string Contenido renderizado
-	 */
+	
 	public function render( $template, array $data, $format = 'html' ) {
 		try {
-			// Verificar si la plantilla existe
+			
 			if ( ! $this->templateExists( $template ) ) {
 				throw new Exception( "Plantilla '{$template}' no encontrada" );
 			}
 			
-			// Intentar obtener de caché
+			
 			$cacheKey = CacheHelper::generateTemplateKey( $template, $data );
 			if ( $this->config['cache_enabled'] ) {
 				$cached = CacheHelper::get( $cacheKey );
@@ -63,21 +40,21 @@ class RenderEngine implements RenderEngineInterface {
 				}
 			}
 			
-			// Obtener contenido de la plantilla
+			
 			$templateContent = $this->getTemplateContent( $template );
 			if ( $templateContent === false ) {
 				throw new Exception( "No se pudo cargar el contenido de la plantilla '{$template}'" );
 			}
 			
-			// Procesar variables en la plantilla
+			
 			$renderedContent = $this->processVariables( $templateContent, $data );
 			
-			// Cachear si está habilitado
+			
 			if ( $this->config['cache_enabled'] ) {
 				CacheHelper::set( $cacheKey, $renderedContent, $this->config['cache_duration'] );
 			}
 			
-			// Aplicar adaptador de formato
+			
 			return $this->applyFormatAdapter( $renderedContent, $format );
 			
 		} catch ( Exception $e ) {
@@ -86,25 +63,20 @@ class RenderEngine implements RenderEngineInterface {
 		}
 	}
 	
-	/**
-	 * Carga una vista previa de plantilla
-	 * 
-	 * @param array $data Datos del request
-	 * @return array Resultado con vista previa
-	 */
+	
 	public function loadTemplatePreview( array $data ) {
 		try {
-			// Validar datos requeridos
+			
 			if ( empty( $data['template'] ) ) {
 				return new WP_Error( 'missing_template', 'Nombre de plantilla requerido' );
 			}
 			
 			$templateName = sanitize_text_field( $data['template'] );
 			
-			// Datos de ejemplo para la preview
+			
 			$previewData = $this->generatePreviewData( $data );
 			
-			// Renderizar plantilla
+			
 			$htmlContent = $this->render( $templateName, $previewData, 'html' );
 			$textContent = $this->render( $templateName, $previewData, 'text' );
 			
@@ -122,16 +94,10 @@ class RenderEngine implements RenderEngineInterface {
 		}
 	}
 	
-	/**
-	 * Crea una nueva plantilla
-	 * 
-	 * @param array      $formData Datos del formulario
-	 * @param array|null $yachtData Datos del yate (opcional)
-	 * @return array Resultado de la creación
-	 */
+	
 	public function createTemplate( array $formData, $yachtData = null ) {
 		try {
-			// Validar datos del formulario
+			
 			$requiredFields = array( 'currency' );
 			foreach ( $requiredFields as $field ) {
 				if ( empty( $formData[ $field ] ) ) {
@@ -139,17 +105,17 @@ class RenderEngine implements RenderEngineInterface {
 				}
 			}
 			
-			// Determinar plantilla a usar
+			
 			$templateName = $formData['selectedTemplate'] ?? $this->config['default_template'];
 			
-			// Preparar datos para el template
+			
 			$templateData = $this->prepareTemplateData( $formData, $yachtData );
 			
-			// Renderizar template
+			
 			$htmlContent = $this->render( $templateName, $templateData, 'html' );
 			$textContent = $this->render( $templateName, $templateData, 'text' );
 			
-			// Generar resultado
+			
 			$result = array(
 				'template_name' => $templateName,
 				'html_content'  => $htmlContent,
@@ -160,7 +126,7 @@ class RenderEngine implements RenderEngineInterface {
 				'success'       => true,
 			);
 			
-			// Guardar template si se solicita
+			
 			if ( ! empty( $formData['saveTemplate'] ) && ! empty( $formData['templateName'] ) ) {
 				$saveResult      = $this->saveCustomTemplate( $formData['templateName'], $templateData, $htmlContent );
 				$result['saved'] = $saveResult;
@@ -174,32 +140,18 @@ class RenderEngine implements RenderEngineInterface {
 		}
 	}
 	
-	/**
-	 * Obtiene lista de plantillas disponibles
-	 * 
-	 * @return array Lista de plantillas
-	 */
+	
 	public function getAvailableTemplates() {
 		return $this->config['available_templates'];
 	}
 	
-	/**
-	 * Verifica si una plantilla existe
-	 * 
-	 * @param string $template Nombre de la plantilla
-	 * @return bool
-	 */
+	
 	public function templateExists( $template ) {
 		$templatePath = $this->getTemplatePath( $template );
 		return file_exists( $templatePath );
 	}
 	
-	/**
-	 * Obtiene el contenido de una plantilla
-	 * 
-	 * @param string $template Nombre de la plantilla
-	 * @return string|false Contenido de la plantilla o false
-	 */
+	
 	public function getTemplateContent( $template ) {
 		$templatePath = $this->getTemplatePath( $template );
 		
@@ -207,11 +159,11 @@ class RenderEngine implements RenderEngineInterface {
 			return false;
 		}
 		
-		// Usar output buffering para capturar el contenido
+		
 		ob_start();
 		
 		try {
-			// Variables disponibles en la plantilla
+			
 			$yacht_data    = array();
 			$calc_data     = array();
 			$template_vars = array();
@@ -230,21 +182,15 @@ class RenderEngine implements RenderEngineInterface {
 		}
 	}
 	
-	/**
-	 * Procesa variables en el contenido de la plantilla
-	 * 
-	 * @param string $content Contenido con variables
-	 * @param array  $variables Variables a reemplazar
-	 * @return string Contenido procesado
-	 */
+	
 	public function processVariables( $content, array $variables ) {
-		// Procesar variables con sintaxis {{variable}}
+		
 		$content = preg_replace_callback(
 			'/\{\{([^}]+)\}\}/',
 			function( $matches ) use ( $variables ) {
 				$varName = trim( $matches[1] );
 			
-				// Soportar notación punto para arrays anidados
+				
 				if ( strpos( $varName, '.' ) !== false ) {
 					$parts = explode( '.', $varName );
 					$value = $variables;
@@ -253,79 +199,71 @@ class RenderEngine implements RenderEngineInterface {
 						if ( isset( $value[ $part ] ) ) {
 							$value = $value[ $part ];
 						} else {
-							return $matches[0]; // Retornar sin cambios si no existe
+							return $matches[0]; 
 						}
 					}
 				
 					return is_array( $value ) ? json_encode( $value ) : (string) $value;
 				}
 			
-				// Variable simple
+				
 				return isset( $variables[ $varName ] ) ? (string) $variables[ $varName ] : $matches[0];
 			},
 			$content
 		);
 		
-		// Procesar bloques condicionales {{#if variable}}...{{/if}}
+		
 		$content = $this->processConditionalBlocks( $content, $variables );
 		
-		// Procesar loops {{#each array}}...{{/each}}
+		
 		$content = $this->processLoopBlocks( $content, $variables );
 		
 		return $content;
 	}
 	
-	/**
-	 * Registra adaptadores de formato por defecto
-	 */
+	
 	private function registerDefaultAdapters() {
-		// Adaptador HTML (por defecto, no hace nada)
+		
 		$this->formatAdapters['html'] = function( $content ) {
 			return $content;
 		};
 		
-		// Adaptador texto plano
+		
 		$this->formatAdapters['text'] = function( $content ) {
-			// Remover tags HTML
+			
 			$text = strip_tags( $content );
 			
-			// Limpiar espacios extra
+			
 			$text = preg_replace( '/\s+/', ' ', $text );
 			
-			// Convertir entities HTML
+			
 			$text = html_entity_decode( $text, ENT_QUOTES, 'UTF-8' );
 			
 			return trim( $text );
 		};
 		
-		// Adaptador Email HTML
+		
 		$this->formatAdapters['email'] = function( $content ) {
-			// Aplicar estilos inline para compatibilidad con clientes de email
+			
 			return $this->applyEmailStyles( $content );
 		};
 	}
 	
-	/**
-	 * Aplica un adaptador de formato al contenido
-	 */
+	
 	private function applyFormatAdapter( $content, $format ) {
 		if ( isset( $this->formatAdapters[ $format ] ) ) {
 			return $this->formatAdapters[ $format ]( $content );
 		}
 		
-		return $content; // Retornar sin cambios si no hay adaptador
+		return $content; 
 	}
 	
-	/**
-	 * Obtiene la ruta completa de una plantilla
-	 */
+	
 	private function getTemplatePath( $template ) {
 		return $this->config['templates_path'] . $template . '.php';
 	}
 	
-	/**
-	 * Genera datos de ejemplo para vista previa
-	 */
+	
 	private function generatePreviewData( array $data ) {
 		return array(
 			'yacht_name'     => 'EJEMPLO YACHT',
@@ -345,9 +283,7 @@ class RenderEngine implements RenderEngineInterface {
 		);
 	}
 	
-	/**
-	 * Prepara datos para el template desde el formulario
-	 */
+	
 	private function prepareTemplateData( array $formData, $yachtData = null ) {
 		$data = array(
 			'currency'     => $formData['currency'],
@@ -355,7 +291,7 @@ class RenderEngine implements RenderEngineInterface {
 			'generated_at' => current_time( 'mysql' ),
 		);
 		
-		// Agregar datos del yate si están disponibles
+		
 		if ( $yachtData && ! is_wp_error( $yachtData ) ) {
 			$data['yacht']        = $yachtData;
 			$data['yacht_name']   = $yachtData['name'] ?? 'Yacht';
@@ -364,7 +300,7 @@ class RenderEngine implements RenderEngineInterface {
 			$data['yacht_cabins'] = $yachtData['cabins'] ?? '';
 		}
 		
-		// Agregar datos calculados si están en el formulario
+		
 		if ( isset( $formData['calculationResult'] ) ) {
 			$data['calculation'] = $formData['calculationResult'];
 		}
@@ -372,9 +308,7 @@ class RenderEngine implements RenderEngineInterface {
 		return $data;
 	}
 	
-	/**
-	 * Procesa bloques condicionales en el template
-	 */
+	
 	private function processConditionalBlocks( $content, array $variables ) {
 		return preg_replace_callback(
 			'/\{\{#if\s+([^}]+)\}\}(.*?)\{\{\/if\}\}/s',
@@ -382,20 +316,18 @@ class RenderEngine implements RenderEngineInterface {
 				$condition    = trim( $matches[1] );
 				$blockContent = $matches[2];
 			
-				// Evaluar condición simple
+				
 				if ( isset( $variables[ $condition ] ) && $variables[ $condition ] ) {
 					return $blockContent;
 				}
 			
-				return ''; // Ocultar bloque si la condición es falsa
+				return ''; 
 			},
 			$content
 		);
 	}
 	
-	/**
-	 * Procesa bloques de loop en el template
-	 */
+	
 	private function processLoopBlocks( $content, array $variables ) {
 		return preg_replace_callback(
 			'/\{\{#each\s+([^}]+)\}\}(.*?)\{\{\/each\}\}/s',
@@ -411,13 +343,13 @@ class RenderEngine implements RenderEngineInterface {
 				foreach ( $variables[ $arrayName ] as $index => $item ) {
 					$itemContent = $loopContent;
 				
-					// Reemplazar {{this}} con el valor del item
+					
 					$itemContent = str_replace( '{{this}}', (string) $item, $itemContent );
 				
-					// Reemplazar {{@index}} con el índice
+					
 					$itemContent = str_replace( '{{@index}}', (string) $index, $itemContent );
 				
-					// Si el item es un array, procesar sus propiedades
+					
 					if ( is_array( $item ) ) {
 						foreach ( $item as $key => $value ) {
 							$itemContent = str_replace( '{{' . $key . '}}', (string) $value, $itemContent );
@@ -433,11 +365,9 @@ class RenderEngine implements RenderEngineInterface {
 		);
 	}
 	
-	/**
-	 * Aplica estilos inline para emails
-	 */
+	
 	private function applyEmailStyles( $content ) {
-		// Estilos básicos para compatibilidad con clientes de email
+		
 		$styles = array(
 			'body'  => 'font-family: Arial, sans-serif; line-height: 1.6; color: #333;',
 			'table' => 'border-collapse: collapse; width: 100%;',
@@ -452,13 +382,11 @@ class RenderEngine implements RenderEngineInterface {
 		return $content;
 	}
 	
-	/**
-	 * Guarda un template personalizado
-	 */
+	
 	private function saveCustomTemplate( $name, array $data, $content ) {
 		try {
-			// Aquí podrías implementar guardado en base de datos
-			// Por ahora, solo retornamos éxito
+			
+			
 			return array(
 				'success'       => true,
 				'template_name' => $name,

--- a/app_yacht/modules/template/php/calculate-template.php
+++ b/app_yacht/modules/template/php/calculate-template.php
@@ -1,19 +1,19 @@
 <?php
-// ARCHIVO: modules/template/php/calculate-template.php
+
 
 require_once get_template_directory() . '/app_yacht/modules/calc/php/calculate.php';
 require_once get_template_directory() . '/app_yacht/modules/template/php/template-data.php';
 require_once get_template_directory() . '/app_yacht/shared/php/currency-functions.php';
 
 function calcularResultadosTemplate( array $data ): array {
-	// Validar datos de entrada
+	
 	if ( empty( $data['charterRates'] ) ) {
 		error_log( 'Empty charterRates in calcularResultadosTemplate()' );
 		return array();
 	}
 
 	try {
-		$structuredResults = calculate( $data ); // <-- llama a la del módulo 1
+		$structuredResults = calculate( $data ); 
 		return $structuredResults;
 	} catch ( Exception $e ) {
 		error_log( 'Error in calcularResultadosTemplate: ' . $e->getMessage() );

--- a/app_yacht/modules/template/php/template-data.php
+++ b/app_yacht/modules/template/php/template-data.php
@@ -1,10 +1,7 @@
 <?php
-// Archivo: modules/template/php/template-data.php
 
-/**
- * buildYachtInfoArray($yachtInfo)
- * Retorna un array con la info del yate
- */
+
+
 function buildYachtInfoArray( array $yachtInfo = array() ): array {
 	return array(
 		'yachtName'          => $yachtInfo['yachtName'] ?? '--',
@@ -21,12 +18,9 @@ function buildYachtInfoArray( array $yachtInfo = array() ): array {
 	);
 }
 
-/**
- * buildCalcSnippetArray($resultArray, $lowSeasonText, $highSeasonText)
- * Combina la info de "mix text" + el primer (o varios) bloques de $resultArray
- */
+
 function buildCalcSnippetArray( array $resultArray, string $lowSeasonText = '', string $highSeasonText = '' ): array {
-	// 1) Parsear Low Season
+	
 	$lowInfo = '';
 	$lowCost = '';
 	if ( $lowSeasonText ) {
@@ -35,7 +29,7 @@ function buildCalcSnippetArray( array $resultArray, string $lowSeasonText = '', 
 		$lowCost  = trim( $lowParts[1] ?? '' );
 	}
 
-	// 2) Parsear High Season
+	
 	$highInfo = '';
 	$highCost = '';
 	if ( $highSeasonText ) {
@@ -44,31 +38,31 @@ function buildCalcSnippetArray( array $resultArray, string $lowSeasonText = '', 
 		$highCost  = trim( $highParts[1] ?? '' );
 	}
 
-	// 3) Tomar el primer "block"
+	
 	$block = $resultArray[0] ?? array();
 	
-	// Asegurarse de que enableExpenses se mantenga en el bloque estructurado
-	// si no está presente en el bloque, pero sí en templateData global
+	
+	
 	global $templateData;
 	if ( isset( $templateData ) && isset( $templateData['enableExpenses'] ) ) {
 		$block['enableExpenses'] = $templateData['enableExpenses'];
 		
-		// También aplicar enableExpenses a todos los elementos en resultArray
-		// para asegurar que esté disponible en cada bloque cuando se itera en el template
+		
+		
 		foreach ( $resultArray as $key => $value ) {
 			$resultArray[ $key ]['enableExpenses'] = $templateData['enableExpenses'];
 		}
 	} elseif ( isset( $resultArray[0]['enableExpenses'] ) ) {
-		// Si no está en templateData pero sí en el primer resultado, usamos ese valor
+		
 		$block['enableExpenses'] = $resultArray[0]['enableExpenses'];
 	}
 
-	// 4) Armar array final con nombres consistentes
+	
 	return array(
 		'lowMixInfo'      => $lowInfo,
 		'lowMixCost'      => $lowCost,
 		'highMixInfo'     => $highInfo,
 		'highMixCost'     => $highCost,
-		'structuredBlock' => $block, // nombre consistente con default-template.php
+		'structuredBlock' => $block, 
 	);
 }

--- a/app_yacht/modules/template/templates/default-template.php
+++ b/app_yacht/modules/template/templates/default-template.php
@@ -1,32 +1,13 @@
 <?php
-/**
- * Default Email Template (Main Version).
- *
- * This template generates the main HTML email body for yacht charter details.
- * It receives data via the $templateData variable, processes it using helper functions,
- * and populates the HTML structure.
- *
- * @package App_Yacht
- * @subpackage Modules
- * @since 1.0.0
- *
- * @uses buildYachtInfoArray() To structure yacht details.
- * @uses buildCalcSnippetArray() To structure calculation results.
- *
- * @var array $templateData Associative array containing all necessary data:
- *        'yachtInfo'      => (array) Yacht details.
- *        'resultArray'    => (array) Calculation results.
- *        'lowSeasonText'  => (string) Text for low season.
- *        'highSeasonText' => (string) Text for high season.
- */
 
-// Verify received data
+
+
 if ( empty( $templateData['resultArray'] ) ) {
 	error_log( 'Empty resultArray in default-template.php' );
 	error_log( 'Template data: ' . print_r( $templateData, true ) );
 }
 
-// Prepare data arrays using helper functions
+
 $yachtArr = buildYachtInfoArray( $templateData['yachtInfo'] ?? array() );
 $calcArr  = buildCalcSnippetArray(
 	$templateData['resultArray'] ?? array(),
@@ -34,13 +15,13 @@ $calcArr  = buildCalcSnippetArray(
 	$templateData['highSeasonText'] ?? ''
 );
 
-// Verify processed data
+
 if ( empty( $calcArr['structuredBlock'] ) ) {
 	error_log( 'Empty structuredBlock in default-template.php' );
 	error_log( 'Calc array: ' . print_r( $calcArr, true ) );
 }
 
-// Extract the main structured block for easier access in the template
+
 $block = $calcArr['structuredBlock'] ?? array();
 ?>
 <!-- Template que debe copiarse con el botón Copy Template inicio -->
@@ -113,7 +94,7 @@ $block = $calcArr['structuredBlock'] ?? array();
 								<div id="imageSection" class="template-img-section" style="max-width: 395px; min-width: 300px; display: table-cell; vertical-align: top;">
 									<?php
 									if ( ! empty( $yachtArr['imageUrl'] ) ) :
-										// Añadido width: 100%; para asegurar expansión completa
+										
 										?>
 										<div style="color:#ffffff;border-top-left-radius: 6px; border-top-right-radius: 5px; border-bottom-right-radius: 50px; border-bottom-left-radius: 0px;font-size:20px;display:block;border-bottom: 4px solid #ffbe28;background: #4092df; width: 100%;">
 											<a class="template-yacht-name" href="<?php echo htmlspecialchars( $yachtArr['yachtUrl'] ); ?>" id="yachtLink" style="color:#ffffff;font-weight:bold;text-decoration:none;">
@@ -215,7 +196,7 @@ $block = $calcArr['structuredBlock'] ?? array();
 														<td align="left" valign="middle" style="padding: 5px; color: #4b4f54; width: 70%;">
 															<?php if ( $resultData['discountType'] === 'percentage' ) : ?>
 																Discount Rate (<?php echo htmlspecialchars( number_format( floatval( str_replace( array( ',', '%' ), '', $resultData['discountAmount'] ) ), 0, '.', ',' ) ); ?>%):
-															<?php else : // Assuming 'fixed' ?>
+															<?php else : ?>
 																Discount Rate: - <?php echo htmlspecialchars( $resultData['discountAmount'] ); ?> :
 															<?php endif; ?>
 														</td>
@@ -373,7 +354,7 @@ $block = $calcArr['structuredBlock'] ?? array();
 
 
 											<!-- Extras -->
-											<?php if ( ! empty( $resultData['extras'] ) ) : // Show Extras section only if there are extras ?>
+											<?php if ( ! empty( $resultData['extras'] ) ) : ?>
 												<table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0"
 													style="width: 100%; border-spacing: 0; border-collapse: collapse; padding: 2px 5px; color: #4b4f54; font-family: Arial, sans-serif; font-size: 12px; margin-top: 5px;">
 													<!-- Extras Title Row -->
@@ -394,9 +375,9 @@ $block = $calcArr['structuredBlock'] ?? array();
 																</td>
 															</tr>
 														<?php endforeach; ?>
-													<?php endif; // End hideExtras condition ?>
+													<?php endif; ?>
 												</table>
-											<?php endif; // End !empty($resultData['extras']) condition ?>
+											<?php endif; ?>
 
 
 											<!-- Grand Total -->

--- a/app_yacht/modules/template/templates/email-signature.php
+++ b/app_yacht/modules/template/templates/email-signature.php
@@ -1,8 +1,5 @@
 <?php
-/**
- * Template de firma de email
- * Variables disponibles: user_name, user_email, company_name, website
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/app_yacht/modules/template/templates/template-01.php
+++ b/app_yacht/modules/template/templates/template-01.php
@@ -1,5 +1,5 @@
 <?php
-// Verificar datos recibidos
+
 if ( empty( $templateData['resultArray'] ) ) {
 	error_log( 'Empty resultArray in default-template.php' );
 	error_log( 'Template data: ' . print_r( $templateData, true ) );
@@ -12,7 +12,7 @@ $calcArr  = buildCalcSnippetArray(
 	$templateData['highSeasonText'] ?? ''
 );
 
-// Verificar datos procesados
+
 if ( empty( $calcArr['structuredBlock'] ) ) {
 	error_log( 'Empty structuredBlock in default-template.php' );
 	error_log( 'Calc array: ' . print_r( $calcArr, true ) );

--- a/app_yacht/modules/template/templates/template-02-prev.php
+++ b/app_yacht/modules/template/templates/template-02-prev.php
@@ -1,5 +1,5 @@
 <?php
-// Verificar datos recibidos
+
 if ( empty( $templateData['resultArray'] ) ) {
 	error_log( 'Empty resultArray in default-template.php' );
 	error_log( 'Template data: ' . print_r( $templateData, true ) );
@@ -12,7 +12,7 @@ $calcArr  = buildCalcSnippetArray(
 	$templateData['highSeasonText'] ?? ''
 );
 
-// Verificar datos procesados
+
 if ( empty( $calcArr['structuredBlock'] ) ) {
 	error_log( 'Empty structuredBlock in default-template.php' );
 	error_log( 'Calc array: ' . print_r( $calcArr, true ) );

--- a/app_yacht/modules/template/templates/template-02.php
+++ b/app_yacht/modules/template/templates/template-02.php
@@ -1,5 +1,5 @@
 <?php
-// Verificar datos recibidos
+
 if ( empty( $templateData['resultArray'] ) ) {
 	error_log( 'Empty resultArray in default-template.php' );
 	error_log( 'Template data: ' . print_r( $templateData, true ) );
@@ -12,7 +12,7 @@ $calcArr  = buildCalcSnippetArray(
 	$templateData['highSeasonText'] ?? ''
 );
 
-// Verificar datos procesados
+
 if ( empty( $calcArr['structuredBlock'] ) ) {
 	error_log( 'Empty structuredBlock in default-template.php' );
 	error_log( 'Calc array: ' . print_r( $calcArr, true ) );
@@ -189,7 +189,7 @@ $block = $calcArr['structuredBlock'] ?? array();
 											</table>
 											<!-- Descuento -->
 											<?php 
-											// Mostrar la sección de descuento solo si hay un tipo de descuento, un valor de descuento calculado y una tasa descontada válida
+											
 											if ( ! empty( $resultData['discountType'] ) && 
 												isset( $resultData['discountValue'] ) && $resultData['discountValue'] !== '--' && 
 												isset( $resultData['discountedRate'] ) && $resultData['discountedRate'] !== '--' ) : 
@@ -200,7 +200,7 @@ $block = $calcArr['structuredBlock'] ?? array();
 														<td align="left" valign="middle" style="padding: 5px; color: #4b4f54;">
 															<?php if ( $resultData['discountType'] === 'percentage' ) : ?>
 																Discount Rate (<?php echo htmlspecialchars( $resultData['discountAmount'] ); ?>%): -<?php echo htmlspecialchars( $resultData['discountValue'] ); ?> =
-															<?php else : // Monto fijo ?>
+															<?php else : ?>
 																Discount Rate - <?php echo htmlspecialchars( $resultData['discountAmount'] ); ?> =
 															<?php endif; ?>
 														</td>
@@ -338,7 +338,7 @@ $block = $calcArr['structuredBlock'] ?? array();
 												<?php 
 												$hasExtras = false;
 												foreach ( $resultData['extras'] as $extra ) : 
-													// Skip empty extras
+													
 													if ( empty( $extra['name'] ) || empty( $extra['cost'] ) ) {
 														continue;
 													}

--- a/app_yacht/modules/yachtinfo/yacht-info-service.php
+++ b/app_yacht/modules/yachtinfo/yacht-info-service.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Servicio de información de yates
- * Maneja la extracción de datos desde URLs de yates
- * 
- * @package AppYacht\Modules\YachtInfo
- * @version 2.0.0
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -14,57 +8,44 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once __DIR__ . '/../../shared/helpers/cache-helper.php';
 require_once __DIR__ . '/../../shared/helpers/validator-helper.php';
 
-/**
- * Servicio para obtener información de yates
- */
+
 class YachtInfoService implements YachtInfoServiceInterface {
 	
-	/**
-	 * @var array Configuración del servicio
-	 */
+	
 	private $config;
 	
-	/**
-	 * Constructor
-	 * 
-	 * @param array $config Configuración del scraping
-	 */
+	
 	public function __construct( array $config ) {
 		$this->config = $config;
 	}
 	
-	/**
-	 * Extrae información de un yate desde una URL
-	 * 
-	 * @param string $url URL del yate
-	 * @return array|WP_Error Datos del yate o error
-	 */
+	
 	public function extractYachtInfo( $url ) {
 		try {
-			// Validar URL
+			
 			if ( ! ValidatorHelper::isValidUrl( $url ) ) {
 				return new WP_Error( 'invalid_url', 'URL inválida proporcionada' );
 			}
 			
-			// Verificar dominio permitido
+			
 			if ( ! $this->isValidDomain( $url ) ) {
 				return new WP_Error( 'domain_not_allowed', 'Dominio no permitido para scraping' );
 			}
 			
-			// Intentar obtener de caché primero
+			
 			$cached = $this->getCachedData( $url );
 			if ( $cached !== null ) {
 				return $cached;
 			}
 			
-			// Hacer scraping
+			
 			$data = $this->performScraping( $url );
 			
 			if ( is_wp_error( $data ) ) {
 				return $data;
 			}
 			
-			// Cachear resultado
+			
 			$this->setCachedData( $url, $data );
 			
 			return $data;
@@ -75,12 +56,7 @@ class YachtInfoService implements YachtInfoServiceInterface {
 		}
 	}
 	
-	/**
-	 * Valida si una URL es de un dominio permitido
-	 * 
-	 * @param string $url URL a validar
-	 * @return bool
-	 */
+	
 	public function isValidDomain( $url ) {
 		$parsed = parse_url( $url );
 		if ( ! $parsed || ! isset( $parsed['host'] ) ) {
@@ -89,7 +65,7 @@ class YachtInfoService implements YachtInfoServiceInterface {
 		
 		$host = strtolower( $parsed['host'] );
 		
-		// Remover www. si existe
+		
 		if ( strpos( $host, 'www.' ) === 0 ) {
 			$host = substr( $host, 4 );
 		}
@@ -97,45 +73,28 @@ class YachtInfoService implements YachtInfoServiceInterface {
 		return in_array( $host, $this->config['allowed_domains'] );
 	}
 	
-	/**
-	 * Obtiene datos en caché si existen
-	 * 
-	 * @param string $url URL del yate
-	 * @return array|null
-	 */
+	
 	public function getCachedData( $url ) {
 		$cache_key = CacheHelper::generateUrlKey( $url );
 		return CacheHelper::get( $cache_key );
 	}
 	
-	/**
-	 * Guarda datos en caché
-	 * 
-	 * @param string $url URL del yate
-	 * @param array  $data Datos a cachear
-	 */
+	
 	public function setCachedData( $url, array $data ) {
 		$cache_key = CacheHelper::generateUrlKey( $url );
 		CacheHelper::set( $cache_key, $data, $this->config['cache_duration'] );
 	}
 	
-	/**
-	 * Limpia la caché de datos de yates
-	 */
+	
 	public function clearCache() {
-		// Para limpiar toda la caché de URLs necesitaríamos un mecanismo más complejo
-		// Por ahora, limpiamos toda la caché de app_yacht
+		
+		
 		CacheHelper::flush();
 	}
 	
-	/**
-	 * Realiza el scraping real de la URL
-	 * 
-	 * @param string $url URL a scrapear
-	 * @return array|WP_Error Datos extraídos o error
-	 */
+	
 	private function performScraping( $url ) {
-		// Configurar argumentos para wp_remote_get
+		
 		$args = array(
 			'timeout'     => $this->config['timeout'],
 			'redirection' => $this->config['max_redirects'],
@@ -149,7 +108,7 @@ class YachtInfoService implements YachtInfoServiceInterface {
 			),
 		);
 		
-		// Realizar request
+		
 		$response = wp_remote_get( $url, $args );
 		
 		if ( is_wp_error( $response ) ) {
@@ -166,29 +125,23 @@ class YachtInfoService implements YachtInfoServiceInterface {
 			return new WP_Error( 'empty_response', 'Respuesta vacía del servidor' );
 		}
 		
-		// Parsear contenido HTML
+		
 		return $this->parseHtmlContent( $body, $url );
 	}
 	
-	/**
-	 * Parsea el contenido HTML para extraer datos del yate
-	 * 
-	 * @param string $html Contenido HTML
-	 * @param string $url URL original
-	 * @return array Datos extraídos
-	 */
+	
 	private function parseHtmlContent( $html, $url ) {
-		// Usar DOMDocument para parsear HTML
+		
 		$dom = new DOMDocument();
 		
-		// Suprimir errores de HTML mal formado
+		
 		libxml_use_internal_errors( true );
 		$dom->loadHTML( $html );
 		libxml_clear_errors();
 		
 		$xpath = new DOMXPath( $dom );
 		
-		// Datos por defecto
+		
 		$data = array(
 			'name'         => '',
 			'length'       => '',
@@ -205,7 +158,7 @@ class YachtInfoService implements YachtInfoServiceInterface {
 			'scraped_at'   => current_time( 'mysql' ),
 		);
 		
-		// Estrategias de extracción por dominio
+		
 		$host = parse_url( $url, PHP_URL_HOST );
 		
 		switch ( true ) {
@@ -226,23 +179,21 @@ class YachtInfoService implements YachtInfoServiceInterface {
 				break;
 		}
 		
-		// Limpieza final de datos
+		
 		$data = $this->cleanExtractedData( $data );
 		
 		return $data;
 	}
 	
-	/**
-	 * Parser específico para CharterWorld
-	 */
+	
 	private function parseCharterworld( $xpath, $data ) {
-		// Título/nombre del yate
+		
 		$titleNodes = $xpath->query( '//h1[@class="yacht-title"] | //h1[contains(@class, "title")]' );
 		if ( $titleNodes->length > 0 ) {
 			$data['name'] = trim( $titleNodes->item( 0 )->textContent );
 		}
 		
-		// Detalles técnicos
+		
 		$detailsNodes = $xpath->query( '//div[contains(@class, "yacht-details")] | //div[contains(@class, "specifications")]' );
 		if ( $detailsNodes->length > 0 ) {
 			$details = $detailsNodes->item( 0 )->textContent;
@@ -252,11 +203,9 @@ class YachtInfoService implements YachtInfoServiceInterface {
 		return $data;
 	}
 	
-	/**
-	 * Parser específico para YachtCharterFleet
-	 */
+	
 	private function parseYachtCharterFleet( $xpath, $data ) {
-		// Implementar lógica específica para YachtCharterFleet
+		
 		$titleNodes = $xpath->query( '//h1 | //title' );
 		if ( $titleNodes->length > 0 ) {
 			$data['name'] = trim( $titleNodes->item( 0 )->textContent );
@@ -265,11 +214,9 @@ class YachtInfoService implements YachtInfoServiceInterface {
 		return $data;
 	}
 	
-	/**
-	 * Parser específico para Burgess
-	 */
+	
 	private function parseBurgess( $xpath, $data ) {
-		// Implementar lógica específica para Burgess
+		
 		$titleNodes = $xpath->query( '//h1 | //title' );
 		if ( $titleNodes->length > 0 ) {
 			$data['name'] = trim( $titleNodes->item( 0 )->textContent );
@@ -278,17 +225,15 @@ class YachtInfoService implements YachtInfoServiceInterface {
 		return $data;
 	}
 	
-	/**
-	 * Parser genérico para sitios no específicos
-	 */
+	
 	private function parseGeneric( $xpath, $data ) {
-		// Buscar título
+		
 		$titleNodes = $xpath->query( '//h1 | //title' );
 		if ( $titleNodes->length > 0 ) {
 			$data['name'] = trim( $titleNodes->item( 0 )->textContent );
 		}
 		
-		// Buscar meta description
+		
 		$metaNodes = $xpath->query( '//meta[@name="description"]' );
 		if ( $metaNodes->length > 0 ) {
 			$data['description'] = trim( $metaNodes->item( 0 )->getAttribute( 'content' ) );
@@ -297,31 +242,29 @@ class YachtInfoService implements YachtInfoServiceInterface {
 		return $data;
 	}
 	
-	/**
-	 * Extrae detalles técnicos desde texto
-	 */
+	
 	private function extractTechnicalDetails( $text, $data ) {
-		// Longitud
+		
 		if ( preg_match( '/(\d+\.?\d*)\s*m\b/i', $text, $matches ) ) {
 			$data['length'] = $matches[1] . 'm';
 		}
 		
-		// Huéspedes
+		
 		if ( preg_match( '/(\d+)\s*guests?/i', $text, $matches ) ) {
 			$data['guests'] = $matches[1];
 		}
 		
-		// Cabinas
+		
 		if ( preg_match( '/(\d+)\s*cabins?/i', $text, $matches ) ) {
 			$data['cabins'] = $matches[1];
 		}
 		
-		// Tripulación
+		
 		if ( preg_match( '/(\d+)\s*crew/i', $text, $matches ) ) {
 			$data['crew'] = $matches[1];
 		}
 		
-		// Año
+		
 		if ( preg_match( '/\b(19|20)\d{2}\b/', $text, $matches ) ) {
 			$data['year'] = $matches[0];
 		}
@@ -329,9 +272,7 @@ class YachtInfoService implements YachtInfoServiceInterface {
 		return $data;
 	}
 	
-	/**
-	 * Limpia y valida los datos extraídos
-	 */
+	
 	private function cleanExtractedData( $data ) {
 		foreach ( $data as $key => $value ) {
 			if ( is_string( $value ) ) {

--- a/app_yacht/shared/helpers/cache-helper.php
+++ b/app_yacht/shared/helpers/cache-helper.php
@@ -1,67 +1,35 @@
 <?php
-/**
- * Helper para gestión de caché
- * Funciones auxiliares para manejo de caché en App_Yacht
- *
- * @package AppYacht\Helpers
- * @version 2.0.0
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Clase helper para gestión de caché
- */
+
 class CacheHelper {
 
-	/**
-	 * Prefijo para claves de caché
-	 */
+	
 	const CACHE_PREFIX = 'app_yacht_';
 
-	/**
-	 * Obtiene un valor de la caché
-	 *
-	 * @param string $key Clave
-	 * @return mixed|false Valor o false si no existe
-	 */
+	
 	public static function get( $key ) {
 		$full_key = self::CACHE_PREFIX . $key;
 		return wp_cache_get( $full_key, 'app_yacht' );
 	}
 
-	/**
-	 * Guarda un valor en la caché
-	 *
-	 * @param string $key Clave
-	 * @param mixed  $value Valor
-	 * @param int    $expiration Tiempo de expiración en segundos
-	 * @return bool
-	 */
+	
 	public static function set( $key, $value, $expiration = 3600 ) {
 		$full_key = self::CACHE_PREFIX . $key;
 		return wp_cache_set( $full_key, $value, 'app_yacht', $expiration );
 	}
 
-	/**
-	 * Elimina un valor de la caché
-	 *
-	 * @param string $key Clave
-	 * @return bool
-	 */
+	
 	public static function delete( $key ) {
 		$full_key = self::CACHE_PREFIX . $key;
 		return wp_cache_delete( $full_key, 'app_yacht' );
 	}
 
-	/**
-	 * Elimina múltiples valores de la caché
-	 *
-	 * @param array $keys Array de claves
-	 * @return bool
-	 */
+	
 	public static function deleteMultiple( array $keys ) {
 		$success = true;
 		foreach ( $keys as $key ) {
@@ -72,42 +40,22 @@ class CacheHelper {
 		return $success;
 	}
 
-	/**
-	 * Limpia toda la caché de App_Yacht
-	 *
-	 * @return bool
-	 */
+	
 	public static function flush() {
 		return wp_cache_flush_group( 'app_yacht' );
 	}
 
-	/**
-	 * Genera una clave de caché para URL
-	 *
-	 * @param string $url URL
-	 * @return string Clave de caché
-	 */
+	
 	public static function generateUrlKey( $url ) {
 		return 'url_' . md5( $url );
 	}
 
-	/**
-	 * Genera una clave de caché para cálculo
-	 *
-	 * @param array $data Datos del cálculo
-	 * @return string Clave de caché
-	 */
+	
 	public static function generateCalcKey( array $data ) {
 		return 'calc_' . md5( json_encode( $data ) );
 	}
 
-	/**
-	 * Genera una clave de caché para template
-	 *
-	 * @param string $template Nombre del template
-	 * @param array  $data Datos del template
-	 * @return string Clave de caché
-	 */
+	
 	public static function generateTemplateKey( $template, array $data = array() ) {
 		$key = 'template_' . $template;
 		if ( ! empty( $data ) ) {

--- a/app_yacht/shared/helpers/validator-helper.php
+++ b/app_yacht/shared/helpers/validator-helper.php
@@ -1,79 +1,40 @@
 <?php
-/**
- * Helper para validación de datos
- * Funciones auxiliares para validación en App_Yacht
- *
- * @package AppYacht\Helpers
- * @version 2.0.0
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Clase helper para validación
- */
+
 class ValidatorHelper {
 
-	/**
-	 * Valida una URL
-	 *
-	 * @param string $url URL a validar
-	 * @return bool
-	 */
+	
 	public static function isValidUrl( $url ) {
 		return filter_var( $url, FILTER_VALIDATE_URL ) !== false;
 	}
 
-	/**
-	 * Valida un email
-	 *
-	 * @param string $email Email a validar
-	 * @return bool
-	 */
+	
 	public static function isValidEmail( $email ) {
 		return filter_var( $email, FILTER_VALIDATE_EMAIL ) !== false;
 	}
 
-	/**
-	 * Valida un número decimal
-	 *
-	 * @param mixed $value Valor a validar
-	 * @return bool
-	 */
+	
 	public static function isValidDecimal( $value ) {
 		return is_numeric( $value ) && $value >= 0;
 	}
 
-	/**
-	 * Valida un porcentaje (0-100)
-	 *
-	 * @param mixed $value Valor a validar
-	 * @return bool
-	 */
+	
 	public static function isValidPercentage( $value ) {
 		return is_numeric( $value ) && $value >= 0 && $value <= 100;
 	}
 
-	/**
-	 * Valida una moneda soportada
-	 *
-	 * @param string $currency Moneda a validar
-	 * @return bool
-	 */
+	
 	public static function isValidCurrency( $currency ) {
 		$config = AppYachtConfig::get( 'calculation' );
 		return in_array( $currency, $config['supported_currencies'] );
 	}
 
-	/**
-	 * Valida datos requeridos en array
-	 *
-	 * @param array $data Datos a validar
-	 * @param array $required Campos requeridos
-	 * @return array Array de errores (vacío si todo es válido)
-	 */
+	
 	public static function validateRequired( array $data, array $required ) {
 		$errors = array();
 
@@ -86,12 +47,7 @@ class ValidatorHelper {
 		return $errors;
 	}
 
-	/**
-	 * Sanitiza datos de entrada
-	 *
-	 * @param array $data Datos a sanitizar
-	 * @return array Datos sanitizados
-	 */
+	
 	public static function sanitizeInputData( array $data ) {
 		$sanitized = array();
 
@@ -110,25 +66,20 @@ class ValidatorHelper {
 		return $sanitized;
 	}
 
-	/**
-	 * Valida estructura de datos de cálculo
-	 *
-	 * @param array $data Datos a validar
-	 * @return array Errores encontrados
-	 */
+	
 	public static function validateCalculationData( array $data ) {
 		$errors = array();
 
-		// Validar campos requeridos
+		
 		$required = array( 'currency' );
 		$errors   = array_merge( $errors, self::validateRequired( $data, $required ) );
 
-		// Validar moneda
+		
 		if ( isset( $data['currency'] ) && ! self::isValidCurrency( $data['currency'] ) ) {
 			$errors[] = 'Moneda no soportada: ' . $data['currency'];
 		}
 
-		// Validar rates numéricos
+		
 		$numericFields = array( 'vatRate', 'apaAmount', 'apaPercentage', 'relocationFee', 'securityFee' );
 		foreach ( $numericFields as $field ) {
 			if ( isset( $data[ $field ] ) && ! empty( $data[ $field ] ) && ! self::isValidDecimal( $data[ $field ] ) ) {
@@ -139,20 +90,15 @@ class ValidatorHelper {
 		return $errors;
 	}
 
-	/**
-	 * Valida datos de email
-	 *
-	 * @param array $data Datos a validar
-	 * @return array Errores encontrados
-	 */
+	
 	public static function validateEmailData( array $data ) {
 		$errors = array();
 
-		// Validar campos requeridos
+		
 		$required = array( 'to', 'subject', 'message' );
 		$errors   = array_merge( $errors, self::validateRequired( $data, $required ) );
 
-		// Validar emails destinatarios
+		
 		if ( isset( $data['to'] ) ) {
 			$emails = explode( ',', $data['to'] );
 			foreach ( $emails as $email ) {

--- a/app_yacht/shared/interfaces/calc-service-interface.php
+++ b/app_yacht/shared/interfaces/calc-service-interface.php
@@ -1,69 +1,28 @@
 <?php
-/**
- * Interface para el servicio de cálculos
- * Define el contrato para operaciones de cálculo de charter
- *
- * @package AppYacht\Interfaces
- * @version 2.0.0
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Interface para servicios de cálculo
- */
+
 interface CalcServiceInterface {
 
-	/**
-	 * Calcula el charter rate estándar
-	 *
-	 * @param array $data Datos del formulario
-	 * @return array Resultado del cálculo
-	 */
+	
 	public function calculateCharter( array $data);
 
-	/**
-	 * Calcula charter con temporadas mixtas
-	 *
-	 * @param array $data Datos del formulario
-	 * @return array Resultado del cálculo mix
-	 */
+	
 	public function calculateMix( array $data);
 
-	/**
-	 * Valida los datos de entrada para cálculos
-	 *
-	 * @param array $data Datos a validar
-	 * @return bool|WP_Error True si válido, WP_Error si no
-	 */
+	
 	public function validateCalculationData( array $data);
 
-	/**
-	 * Aplica impuestos VAT según configuración
-	 *
-	 * @param float $amount Cantidad base
-	 * @param array $vatConfig Configuración de VAT
-	 * @return float Cantidad con VAT aplicado
-	 */
+	
 	public function applyVAT( $amount, array $vatConfig);
 
-	/**
-	 * Calcula el APA (Advance Provisioning Allowance)
-	 *
-	 * @param float $baseAmount Cantidad base
-	 * @param array $apaConfig Configuración de APA
-	 * @return float Cantidad de APA
-	 */
+	
 	public function calculateAPA( $baseAmount, array $apaConfig);
 
-	/**
-	 * Formatea una cantidad según la moneda
-	 *
-	 * @param float  $amount Cantidad a formatear
-	 * @param string $currency Moneda
-	 * @return string Cantidad formateada
-	 */
+	
 	public function formatCurrency( $amount, $currency);
 }

--- a/app_yacht/shared/interfaces/mail-service-interface.php
+++ b/app_yacht/shared/interfaces/mail-service-interface.php
@@ -1,82 +1,34 @@
 <?php
-/**
- * Interface para el servicio de correo
- * Define el contrato para envío de emails y gestión de correo
- *
- * @package AppYacht\Interfaces
- * @version 2.0.0
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Interface para servicios de correo
- */
+
 interface MailServiceInterface {
 
-	/**
-	 * Envía un email
-	 *
-	 * @param array $data Datos del email (to, subject, message, etc.)
-	 * @return bool|WP_Error True si se envió, WP_Error si falló
-	 */
+	
 	public function sendEmail( array $data);
 
-	/**
-	 * Envía email usando Outlook
-	 *
-	 * @param array $data Datos del email
-	 * @param int   $userId ID del usuario
-	 * @return bool|WP_Error
-	 */
+	
 	public function sendEmailViaOutlook( array $data, $userId);
 
-	/**
-	 * Verifica si un usuario está conectado a Outlook
-	 *
-	 * @param int $userId ID del usuario
-	 * @return bool
-	 */
+	
 	public function isOutlookConnected( $userId);
 
-	/**
-	 * Obtiene la URL de autenticación para Outlook
-	 *
-	 * @return string URL de login
-	 */
+	
 	public function getOutlookLoginUrl();
 
-	/**
-	 * Desconecta la cuenta de Outlook de un usuario
-	 *
-	 * @param int $userId ID del usuario
-	 * @return bool
-	 */
+	
 	public function disconnectOutlook( $userId);
 
-	/**
-	 * Valida los datos de un email
-	 *
-	 * @param array $data Datos a validar
-	 * @return bool|WP_Error
-	 */
+	
 	public function validateEmailData( array $data);
 
-	/**
-	 * Procesa archivos adjuntos
-	 *
-	 * @param array $attachments Archivos adjuntos
-	 * @return array|WP_Error Archivos procesados o error
-	 */
+	
 	public function processAttachments( array $attachments);
 
-	/**
-	 * Genera firma de email
-	 *
-	 * @param int $userId ID del usuario
-	 * @return string HTML de la firma
-	 */
+	
 	public function generateSignature( $userId);
 }

--- a/app_yacht/shared/interfaces/render-engine-interface.php
+++ b/app_yacht/shared/interfaces/render-engine-interface.php
@@ -1,77 +1,31 @@
 <?php
-/**
- * Interface para el motor de renderizado
- * Define el contrato para generación de plantillas y contenido
- *
- * @package AppYacht\Interfaces
- * @version 2.0.0
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Interface para motores de renderizado
- */
+
 interface RenderEngineInterface {
 
-	/**
-	 * Renderiza una plantilla con datos
-	 *
-	 * @param string $template Nombre de la plantilla
-	 * @param array  $data Datos para la plantilla
-	 * @param string $format Formato de salida (html|text)
-	 * @return string Contenido renderizado
-	 */
+	
 	public function render( $template, array $data, $format = 'html');
 
-	/**
-	 * Carga una vista previa de plantilla
-	 *
-	 * @param array $data Datos del request
-	 * @return array Resultado con vista previa
-	 */
+	
 	public function loadTemplatePreview( array $data);
 
-	/**
-	 * Crea una nueva plantilla
-	 *
-	 * @param array      $formData Datos del formulario
-	 * @param array|null $yachtData Datos del yate (opcional)
-	 * @return array Resultado de la creación
-	 */
+	
 	public function createTemplate( array $formData, $yachtData = null);
 
-	/**
-	 * Obtiene lista de plantillas disponibles
-	 *
-	 * @return array Lista de plantillas
-	 */
+	
 	public function getAvailableTemplates();
 
-	/**
-	 * Verifica si una plantilla existe
-	 *
-	 * @param string $template Nombre de la plantilla
-	 * @return bool
-	 */
+	
 	public function templateExists( $template);
 
-	/**
-	 * Obtiene el contenido de una plantilla
-	 *
-	 * @param string $template Nombre de la plantilla
-	 * @return string|false Contenido de la plantilla o false
-	 */
+	
 	public function getTemplateContent( $template);
 
-	/**
-	 * Procesa variables en el contenido de la plantilla
-	 *
-	 * @param string $content Contenido con variables
-	 * @param array  $variables Variables a reemplazar
-	 * @return string Contenido procesado
-	 */
+	
 	public function processVariables( $content, array $variables);
 }

--- a/app_yacht/shared/interfaces/yacht-info-service-interface.php
+++ b/app_yacht/shared/interfaces/yacht-info-service-interface.php
@@ -1,55 +1,25 @@
 <?php
-/**
- * Interface para el servicio de información de yates
- * Define el contrato para obtener datos de yates desde URLs
- *
- * @package AppYacht\Interfaces
- * @version 2.0.0
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Interface para servicios de información de yates
- */
+
 interface YachtInfoServiceInterface {
 
-	/**
-	 * Extrae información de un yate desde una URL
-	 *
-	 * @param string $url URL del yate
-	 * @return array|WP_Error Datos del yate o error
-	 */
+	
 	public function extractYachtInfo( $url);
 
-	/**
-	 * Valida si una URL es de un dominio permitido
-	 *
-	 * @param string $url URL a validar
-	 * @return bool
-	 */
+	
 	public function isValidDomain( $url);
 
-	/**
-	 * Obtiene datos en caché si existen
-	 *
-	 * @param string $url URL del yate
-	 * @return array|null
-	 */
+	
 	public function getCachedData( $url);
 
-	/**
-	 * Guarda datos en caché
-	 *
-	 * @param string $url URL del yate
-	 * @param array  $data Datos a cachear
-	 */
+	
 	public function setCachedData( $url, array $data);
 
-	/**
-	 * Limpia la caché de datos de yates
-	 */
+	
 	public function clearCache();
 }

--- a/app_yacht/shared/php/currency-functions.php
+++ b/app_yacht/shared/php/currency-functions.php
@@ -1,13 +1,11 @@
 <?php
-// ARCHIVO shared\php\currency-functions.php
-/**
- * Función auxiliar para formatear moneda.
- */
+
+
 function formatCurrency( $value, $currencyCode, $round = false ) {
 	$value    = $round ? ceil( $value ) : $value;
 	$decimals = $round ? 0 : 2;
 
-	// Mapeo de símbolos de moneda
+	
 	$symbols = array(
 		'EUR'  => '€',
 		'USD'  => '$',

--- a/app_yacht/shared/php/utils.php
+++ b/app_yacht/shared/php/utils.php
@@ -1,38 +1,20 @@
 <?php
-/**
- * Funciones de utilidad general para App_Yacht
- *
- * Este archivo contiene funciones de utilidad general que pueden ser utilizadas
- * en diferentes partes de la aplicación App_Yacht.
- *
- * @package App_Yacht
- * @subpackage Shared
- * @since 1.0.0
- */
 
-// Evitar acceso directo al archivo
+
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
- * Verifica si un usuario tiene una capacidad específica y maneja el error apropiadamente.
- *
- * Esta función verifica si el usuario actual tiene una capacidad específica de WordPress.
- * Si no tiene la capacidad, registra el intento no autorizado y devuelve un error apropiado.
- *
- * @param string $capability La capacidad de WordPress a verificar.
- * @param string $error_message Mensaje de error personalizado (opcional).
- * @return bool True si el usuario tiene la capacidad, false en caso contrario.
- */
+
 function pb_verify_user_capability( $capability, $error_message = '' ) {
 	if ( ! current_user_can( $capability ) ) {
-		// Registrar intento no autorizado
+		
 		$user_id          = get_current_user_id();
 		$backtrace        = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 2 );
 		$calling_function = isset( $backtrace[1]['function'] ) ? $backtrace[1]['function'] : 'unknown';
 
-		// Usar la función de registro de eventos de seguridad
+		
 		if ( function_exists( 'pb_log_security_event' ) ) {
 			pb_log_security_event(
 				$user_id,
@@ -44,7 +26,7 @@ function pb_verify_user_capability( $capability, $error_message = '' ) {
 				)
 			);
 		} else {
-			// Fallback si la función de registro no está disponible
+			
 			error_log(
 				sprintf(
 					'Intento de acceso no autorizado: Usuario %d, Capacidad %s, Función %s',
@@ -55,7 +37,7 @@ function pb_verify_user_capability( $capability, $error_message = '' ) {
 			);
 		}
 
-		// Devolver error apropiado según el contexto
+		
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			wp_send_json_error(
 				array(

--- a/app_yacht/shared/php/validation.php
+++ b/app_yacht/shared/php/validation.php
@@ -1,40 +1,21 @@
 <?php
-/**
- * ARCHIVO shared/php/validation.php
- * Implementa funciones centralizadas de validación para la aplicación App_Yacht
- */
+
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Salir si se accede directamente
+	exit; 
 }
 
-/**
- * Valida si un valor es un correo electrónico válido
- *
- * @param string $email El correo electrónico a validar
- * @return bool True si es un correo válido, false en caso contrario
- */
+
 function pb_validate_email( $email ) {
 	return filter_var( $email, FILTER_VALIDATE_EMAIL ) !== false;
 }
 
-/**
- * Valida si un valor es una URL válida
- *
- * @param string $url La URL a validar
- * @return bool True si es una URL válida, false en caso contrario
- */
+
 function pb_validate_url( $url ) {
 	return filter_var( $url, FILTER_VALIDATE_URL ) !== false;
 }
 
-/**
- * Valida si un valor es un número entero válido
- *
- * @param mixed $value El valor a validar
- * @param array $options Opciones adicionales (min, max)
- * @return bool True si es un entero válido, false en caso contrario
- */
+
 function pb_validate_int( $value, $options = array() ) {
 	if ( ! is_numeric( $value ) || intval( $value ) != $value ) {
 		return false;
@@ -42,7 +23,7 @@ function pb_validate_int( $value, $options = array() ) {
 
 	$value = intval( $value );
 
-	// Validar rango si se especifica
+	
 	if ( isset( $options['min'] ) && $value < $options['min'] ) {
 		return false;
 	}
@@ -54,13 +35,7 @@ function pb_validate_int( $value, $options = array() ) {
 	return true;
 }
 
-/**
- * Valida si un valor es un número decimal válido
- *
- * @param mixed $value El valor a validar
- * @param array $options Opciones adicionales (min, max, decimals)
- * @return bool True si es un decimal válido, false en caso contrario
- */
+
 function pb_validate_float( $value, $options = array() ) {
 	if ( ! is_numeric( $value ) ) {
 		return false;
@@ -68,7 +43,7 @@ function pb_validate_float( $value, $options = array() ) {
 
 	$value = floatval( $value );
 
-	// Validar rango si se especifica
+	
 	if ( isset( $options['min'] ) && $value < $options['min'] ) {
 		return false;
 	}
@@ -77,7 +52,7 @@ function pb_validate_float( $value, $options = array() ) {
 		return false;
 	}
 
-	// Validar número de decimales si se especifica
+	
 	if ( isset( $options['decimals'] ) ) {
 		$parts = explode( '.', (string) $value );
 		if ( isset( $parts[1] ) && strlen( $parts[1] ) > $options['decimals'] ) {
@@ -88,24 +63,12 @@ function pb_validate_float( $value, $options = array() ) {
 	return true;
 }
 
-/**
- * Valida si un valor está dentro de un conjunto de valores permitidos
- *
- * @param mixed $value El valor a validar
- * @param array $allowed_values Array de valores permitidos
- * @return bool True si el valor está permitido, false en caso contrario
- */
+
 function pb_validate_in_array( $value, $allowed_values ) {
 	return in_array( $value, $allowed_values, true );
 }
 
-/**
- * Valida si un valor tiene una longitud dentro del rango especificado
- *
- * @param string $value El valor a validar
- * @param array  $options Opciones (min_length, max_length)
- * @return bool True si la longitud es válida, false en caso contrario
- */
+
 function pb_validate_length( $value, $options = array() ) {
 	$length = strlen( $value );
 
@@ -120,41 +83,23 @@ function pb_validate_length( $value, $options = array() ) {
 	return true;
 }
 
-/**
- * Valida si un valor coincide con un patrón de expresión regular
- *
- * @param string $value El valor a validar
- * @param string $pattern El patrón de expresión regular
- * @return bool True si coincide con el patrón, false en caso contrario
- */
+
 function pb_validate_regex( $value, $pattern ) {
 	return preg_match( $pattern, $value ) === 1;
 }
 
-/**
- * Valida si un valor es una fecha válida en el formato especificado
- *
- * @param string $date La fecha a validar
- * @param string $format El formato de fecha (por defecto Y-m-d)
- * @return bool True si es una fecha válida, false en caso contrario
- */
+
 function pb_validate_date( $date, $format = 'Y-m-d' ) {
 	$d = DateTime::createFromFormat( $format, $date );
 	return $d && $d->format( $format ) === $date;
 }
 
-/**
- * Valida un conjunto de datos contra un esquema de validación
- *
- * @param array $data Los datos a validar
- * @param array $schema El esquema de validación
- * @return array Array con errores encontrados (vacío si todo es válido)
- */
+
 function pb_validate_data( $data, $schema ) {
 	$errors = array();
 
 	foreach ( $schema as $field => $rules ) {
-		// Verificar si el campo es requerido
+		
 		if ( isset( $rules['required'] ) && $rules['required'] && ( ! isset( $data[ $field ] ) || $data[ $field ] === '' ) ) {
 			$errors[ $field ] = isset( $rules['error_messages']['required'] )
 				? $rules['error_messages']['required']
@@ -162,12 +107,12 @@ function pb_validate_data( $data, $schema ) {
 			continue;
 		}
 
-		// Si el campo no está presente y no es requerido, continuar
+		
 		if ( ! isset( $data[ $field ] ) ) {
 			continue;
 		}
 
-		// Validar según el tipo
+		
 		if ( isset( $rules['type'] ) ) {
 			$value = $data[ $field ];
 			$valid = true;
@@ -211,7 +156,7 @@ function pb_validate_data( $data, $schema ) {
 			}
 		}
 
-		// Validaciones personalizadas
+		
 		if ( isset( $rules['custom_validator'] ) && is_callable( $rules['custom_validator'] ) ) {
 			$result = call_user_func( $rules['custom_validator'], $data[ $field ], $data );
 			if ( $result !== true ) {

--- a/app_yacht/shared/php/yachtscan.php
+++ b/app_yacht/shared/php/yachtscan.php
@@ -1,6 +1,6 @@
 <?php
-// ARCHIVO: shared/php/yachtscan.php
-// Funcionalidad centralizada para extracción de info de yates y globalización
+
+
 
 global $yachtInfoGlobal;
 $yachtInfoGlobal = array();
@@ -73,10 +73,10 @@ function extraerInformacionYate( $url ) {
 	$xpath = new DOMXPath( $dom );
 
 	$yachtNameNode = $xpath->query( '//title' )->item( 0 );
-	// Registrar el HTML para depuración
+	
 	error_log( 'YachtScan: HTML snippet: ' . substr( $html, 0, 500 ) . '...' );
 
-	// Consultas a spans que contienen el strong con el label
+	
 	 $lengthNode    = $xpath->query( "//span[contains(strong, 'Length :')]" )->item( 0 );
 	 $builderNode   = $xpath->query( "//span[contains(strong, 'Builder :')]" )->item( 0 );
 	 $yearBuiltNode = $xpath->query( "//span[contains(strong, 'Year Built :')]" )->item( 0 );
@@ -95,7 +95,7 @@ function extraerInformacionYate( $url ) {
 	 error_log( 'YachtScan: kingNode content: ' . ( $kingNode ? $kingNode->textContent : 'null' ) );
 	 error_log( 'YachtScan: queenNode content: ' . ( $queenNode ? $queenNode->textContent : 'null' ) );
 
-	// Registrar resultados de las consultas XPath
+	
 	error_log(
 		'YachtScan: XPath results - Length: ' . ( $lengthNode ? 'found' : 'not found' ) .
 			  ', Builder: ' . ( $builderNode ? 'found' : 'not found' ) .
@@ -134,12 +134,9 @@ function extraerInformacionYate( $url ) {
 	return $result;
 }
 
-/**
- * buildCalcSnippetArray($resultArray, $lowSeasonText, $highSeasonText)
- * Combina la info de "mix text" + el primer (o varios) bloques de $resultArray
- */
+
 function buildCalcSnippetArray( array $resultArray, string $lowSeasonText = '', string $highSeasonText = '' ): array {
-	// 1) Parsear Low Season
+	
 	$lowInfo = '';
 	$lowCost = '';
 	if ( $lowSeasonText ) {
@@ -148,7 +145,7 @@ function buildCalcSnippetArray( array $resultArray, string $lowSeasonText = '', 
 		$lowCost  = trim( $lowParts[1] ?? '' );
 	}
 
-	// 2) Parsear High Season
+	
 	$highInfo = '';
 	$highCost = '';
 	if ( $highSeasonText ) {
@@ -157,31 +154,31 @@ function buildCalcSnippetArray( array $resultArray, string $lowSeasonText = '', 
 		$highCost  = trim( $highParts[1] ?? '' );
 	}
 
-	// 3) Tomar el primer "block"
+	
 	$block = $resultArray[0] ?? array();
 
-	// Asegurarse de que enableExpenses se mantenga en el bloque estructurado
-	// si no está presente en el bloque, pero sí en templateData global
+	
+	
 	global $templateData;
 	if ( isset( $templateData ) && isset( $templateData['enableExpenses'] ) ) {
 		$block['enableExpenses'] = $templateData['enableExpenses'];
 
-		// También aplicar enableExpenses a todos los elementos en resultArray
-		// para asegurar que esté disponible en cada bloque cuando se itera en el template
+		
+		
 		foreach ( $resultArray as $key => $value ) {
 			$resultArray[ $key ]['enableExpenses'] = $templateData['enableExpenses'];
 		}
 	} elseif ( isset( $resultArray[0]['enableExpenses'] ) ) {
-		// Si no está en templateData pero sí en el primer resultado, usamos ese valor
+		
 		$block['enableExpenses'] = $resultArray[0]['enableExpenses'];
 	}
 
-	// 4) Armar array final con nombres consistentes
+	
 	return array(
 		'lowMixInfo'      => $lowInfo,
 		'lowMixCost'      => $lowCost,
 		'highMixInfo'     => $highInfo,
 		'highMixCost'     => $highCost,
-		'structuredBlock' => $block, // nombre consistente con default-template.php
+		'structuredBlock' => $block, 
 	);
 }

--- a/archive.php
+++ b/archive.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * The template for displaying archive pages
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
- *
- * @package ProBroke
- */
+
 
 get_header();
 ?>
@@ -22,15 +16,11 @@ get_header();
 			</header><!-- .page-header -->
 
 			<?php
-			/* Start the Loop */
+			
 			while ( have_posts() ) :
 				the_post();
 
-				/*
-				 * Include the Post-Type-specific template for the content.
-				 * If you want to override this in a child theme, then include a file
-				 * called content-___.php (where ___ is the Post Type name) and that will be used instead.
-				 */
+				
 				get_template_part( 'template-parts/content', get_post_type() );
 
 			endwhile;

--- a/comments.php
+++ b/comments.php
@@ -1,20 +1,7 @@
 <?php
-/**
- * The template for displaying comments
- *
- * This is the template that displays the area of the page that contains both the current comments
- * and the comment form.
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
- *
- * @package ProBroke
- */
 
-/*
- * If the current post is protected by a password and
- * the visitor has not yet entered the password we will
- * return early without loading the comments.
- */
+
+
 if ( post_password_required() ) {
 	return;
 }
@@ -23,7 +10,7 @@ if ( post_password_required() ) {
 <div id="comments" class="comments-area">
 
 	<?php
-	// You can start editing here -- including this comment!
+	
 	if ( have_comments() ) :
 		?>
 		<h2 class="comments-title">
@@ -31,15 +18,15 @@ if ( post_password_required() ) {
 			$creativoypunto_comment_count = get_comments_number();
 			if ( '1' === $creativoypunto_comment_count ) {
 				printf(
-					/* translators: 1: title. */
+					
 					esc_html__( 'One thought on &ldquo;%1$s&rdquo;', 'creativoypunto' ),
 					'<span>' . wp_kses_post( get_the_title() ) . '</span>'
 				);
 			} else {
 				printf(
-					/* translators: 1: comment count number, 2: title. */
+					
 					esc_html( _nx( '%1$s thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', $creativoypunto_comment_count, 'comments title', 'creativoypunto' ) ),
-					number_format_i18n( $creativoypunto_comment_count ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					number_format_i18n( $creativoypunto_comment_count ), 
 					'<span>' . wp_kses_post( get_the_title() ) . '</span>'
 				);
 			}
@@ -62,14 +49,14 @@ if ( post_password_required() ) {
 		<?php
 		the_comments_navigation();
 
-		// If comments are closed and there are comments, let's leave a little note, shall we?
+		
 		if ( ! comments_open() ) :
 			?>
 			<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'creativoypunto' ); ?></p>
 			<?php
 		endif;
 
-	endif; // Check for have_comments().
+	endif; 
 
 	comment_form();
 	?>

--- a/footer.php
+++ b/footer.php
@@ -1,13 +1,5 @@
 <?php
-/**
- * The template for displaying the footer
- *
- * Contains the closing of the #content div and all content after.
- *
- * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
- *
- * @package ProBroke
- */
+
 
 ?>
 
@@ -15,13 +7,13 @@
 		<div class="site-info">
 			<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'creativoypunto' ) ); ?>">
 				<?php
-				/* translators: %s: CMS name, i.e. WordPress. */
+				
 				printf( esc_html__( 'Proudly powered by %s', 'creativoypunto' ), 'WordPress' );
 				?>
 			</a>
 			<span class="sep"> | </span>
 				<?php
-				/* translators: 1: Theme name, 2: Theme author. */
+				
 				printf( esc_html__( 'Theme: %1$s by %2$s.', 'creativoypunto' ), 'creativoypunto', '<a href="https://creativoypunto.com">Mr_ShadoW</a>' );
 				?>
 		</div><!-- .site-info -->

--- a/functions.php
+++ b/functions.php
@@ -1,25 +1,13 @@
 <?php
-/**
- * ProBroke functions and definitions
- *
- * @link https://developer.wordpress.org/themes/basics/theme-functions/
- *
- * @package ProBroke
- */
+
 
 if ( ! defined( '_S_VERSION' ) ) {
-		// Replace the version number of the theme on each release.
+		
 		define( '_S_VERSION', '1.0.0' );
 }
 
-/**
- * Sets up theme defaults and registers support for various WordPress features.
- *
- * Note that this function is hooked into the after_setup_theme hook, which
- * runs before the init hook. The init hook is too late for some features, such
- * as indicating support for post thumbnails.
- */
-// ==================== APP mail ==================== //
+
+
 add_action( 'wp_ajax_gmail_auth', 'handle_gmail_auth_request' );
 function handle_gmail_auth_request() {
 	check_ajax_referer( 'mail_nonce', 'security' );
@@ -59,46 +47,29 @@ function app_mail_handle_routes( $template ) {
 	return $template;
 }
 
-// ==================== END APP mail ==================== //
+
 
 function creativoypunto_setup() {
-		/*
-				* Make theme available for translation.
-				* Translations can be filed in the /languages/ directory.
-				* If you're building a theme based on ProBroke, use a find and replace
-				* to change 'creativoypunto' to the name of your theme in all the template files.
-				*/
+		
 		load_theme_textdomain( 'creativoypunto', get_template_directory() . '/languages' );
 
-		// Add default posts and comments RSS feed links to head.
+		
 		add_theme_support( 'automatic-feed-links' );
 
-		/*
-				* Let WordPress manage the document title.
-				* By adding theme support, we declare that this theme does not use a
-				* hard-coded <title> tag in the document head, and expect WordPress to
-				* provide it for us.
-				*/
+		
 		add_theme_support( 'title-tag' );
 
-		/*
-				* Enable support for Post Thumbnails on posts and pages.
-				*
-				* @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
-				*/
+		
 		add_theme_support( 'post-thumbnails' );
 
-		// This theme uses wp_nav_menu() in one location.
+		
 		register_nav_menus(
 			array(
 				'menu-1' => esc_html__( 'Primary', 'creativoypunto' ),
 			)
 		);
 
-		/*
-				* Switch default core markup for search form, comment form, and comments
-				* to output valid HTML5.
-				*/
+		
 		add_theme_support(
 			'html5',
 			array(
@@ -112,7 +83,7 @@ function creativoypunto_setup() {
 			)
 		);
 
-		// Set up the WordPress core custom background feature.
+		
 		add_theme_support(
 			'custom-background',
 			apply_filters(
@@ -124,14 +95,10 @@ function creativoypunto_setup() {
 			)
 		);
 
-		// Add theme support for selective refresh for widgets.
+		
 		add_theme_support( 'customize-selective-refresh-widgets' );
 
-		/**
-		 * Add support for core custom logo.
-		 *
-		 * @link https://codex.wordpress.org/Theme_Logo
-		 */
+		
 		add_theme_support(
 			'custom-logo',
 			array(
@@ -144,23 +111,13 @@ function creativoypunto_setup() {
 }
 add_action( 'after_setup_theme', 'creativoypunto_setup' );
 
-/**
- * Set the content width in pixels, based on the theme's design and stylesheet.
- *
- * Priority 0 to make it available to lower priority callbacks.
- *
- * @global int $content_width
- */
+
 function creativoypunto_content_width() {
 		$GLOBALS['content_width'] = apply_filters( 'creativoypunto_content_width', 640 );
 }
 add_action( 'after_setup_theme', 'creativoypunto_content_width', 0 );
 
-/**
- * Register widget area.
- *
- * @link https://developer.wordpress.org/themes/functionality/sidebars/#registering-a-sidebar
- */
+
 function creativoypunto_widgets_init() {
 		register_sidebar(
 			array(
@@ -176,7 +133,7 @@ function creativoypunto_widgets_init() {
 }
 add_action( 'widgets_init', 'creativoypunto_widgets_init' );
 
-// ==================== AUTO HIDE MENU ====================//
+
 require_once get_template_directory() . '/inc/menu-creativoypunto.php';
 
 function enqueue_custom_scripts() {
@@ -188,11 +145,11 @@ function menu_creativoypunto() {
 	wp_enqueue_style( 'menu_creativoypunto', get_template_directory_uri() . '/css/menu-creativoypunto.css' );
 }
 add_action( 'wp_enqueue_scripts', 'menu_creativoypunto' );
-// ==================== END AUTO HIDE MENU ====================//
 
-// ==================== SCRIPTS AND STYLES ====================//
+
+
 function enqueue_bootstrap_local() {
-	// Bootstrap local
+	
 	wp_enqueue_style( 'bootstrap-css', get_template_directory_uri() . '/bootstrap/css/bootstrap.min.css' );
 	wp_enqueue_script( 'bootstrap-js', get_template_directory_uri() . '/bootstrap/js/bootstrap.bundle.min.js', array( 'jquery' ), null, true );
 }
@@ -220,9 +177,9 @@ function enqueue_construction_styles() {
 	}
 }
 add_action( 'wp_enqueue_scripts', 'enqueue_construction_styles' );
-// ==================== END SCRIPTS AND STYLES ====================//
 
-// Additional includes
+
+
 require get_template_directory() . '/inc/custom-header.php';
 require get_template_directory() . '/inc/template-tags.php';
 require get_template_directory() . '/inc/template-functions.php';
@@ -234,11 +191,11 @@ if ( class_exists( 'WooCommerce' ) ) {
 	require get_template_directory() . '/inc/woocommerce.php';
 }
 
-// ==================== APP YACHT v2.0 ====================//
-// Nueva arquitectura refactorizada - carga bootstrap principal
+
+
 require_once get_template_directory() . '/app_yacht/core/bootstrap.php';
 
-// Inicializar App Yacht con nueva arquitectura
+
 add_action(
 	'init',
 	function() {
@@ -255,17 +212,15 @@ add_action(
 	}
 );
 
-// Mantener compatibilidad con funciones legacy si existen
+
 $legacy_yacht_functions = get_template_directory() . '/app_yacht/core/yacht-functions.php';
 if ( file_exists( $legacy_yacht_functions ) ) {
 	require_once $legacy_yacht_functions;
 }
-// ==================== APP YACHT v2.0 END====================//
 
 
-/**
- * Deshabilitar jQuery Migrate en frontend si no se necesita
- */
+
+
 function remove_jquery_migrate_script( &$scripts ) {
 	if ( ! is_admin() && isset( $scripts->registered['jquery'] ) ) {
 		$script = $scripts->registered['jquery'];

--- a/header.php
+++ b/header.php
@@ -1,13 +1,5 @@
 <?php
-/**
- * The header for our theme
- *
- * This is the template that displays all of the <head> section and everything up until <div id="content">
- *
- * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
- *
- * @package creativoypunto
- */
+
 
 ?>
 <!doctype html>
@@ -71,4 +63,4 @@
 			</nav>
 		</div>
 	</header>
-	<?php // get_footer(); ?>
+	<?php ?>

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -1,21 +1,7 @@
 <?php
-/**
- * Sample implementation of the Custom Header feature
- *
- * You can add an optional custom header image to header.php like so ...
- *
-	<?php the_header_image_tag(); ?>
- *
- * @link https://developer.wordpress.org/themes/functionality/custom-headers/
- *
- * @package ProBroke
- */
 
-/**
- * Set up the WordPress core custom header feature.
- *
- * @uses creativoypunto_header_style()
- */
+
+
 function creativoypunto_custom_header_setup() {
 	add_theme_support(
 		'custom-header',
@@ -35,27 +21,20 @@ function creativoypunto_custom_header_setup() {
 add_action( 'after_setup_theme', 'creativoypunto_custom_header_setup' );
 
 if ( ! function_exists( 'creativoypunto_header_style' ) ) :
-	/**
-	 * Styles the header image and text displayed on the blog.
-	 *
-	 * @see creativoypunto_custom_header_setup().
-	 */
+	
 	function creativoypunto_header_style() {
 		$header_text_color = get_header_textcolor();
 
-		/*
-		 * If no custom options for text are set, let's bail.
-		 * get_header_textcolor() options: Any hex value, 'blank' to hide text. Default: add_theme_support( 'custom-header' ).
-		 */
+		
 		if ( get_theme_support( 'custom-header', 'default-text-color' ) === $header_text_color ) {
 			return;
 		}
 
-		// If we get this far, we have custom styles. Let's do this.
+		
 		?>
 		<style type="text/css">
 		<?php
-		// Has the text been hidden?
+		
 		if ( ! display_header_text() ) :
 			?>
 			.site-title,
@@ -64,7 +43,7 @@ if ( ! function_exists( 'creativoypunto_header_style' ) ) :
 				clip: rect(1px, 1px, 1px, 1px);
 				}
 			<?php
-			// If the user has set a custom color for the text use that.
+			
 		else :
 			?>
 			.site-title a,

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1,15 +1,7 @@
 <?php
-/**
- * ProBroke Theme Customizer
- *
- * @package ProBroke
- */
 
-/**
- * Add postMessage support for site title and description for the Theme Customizer.
- *
- * @param WP_Customize_Manager $wp_customize Theme Customizer object.
- */
+
+
 function creativoypunto_customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
 	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
@@ -34,27 +26,17 @@ function creativoypunto_customize_register( $wp_customize ) {
 }
 add_action( 'customize_register', 'creativoypunto_customize_register' );
 
-/**
- * Render the site title for the selective refresh partial.
- *
- * @return void
- */
+
 function creativoypunto_customize_partial_blogname() {
 	bloginfo( 'name' );
 }
 
-/**
- * Render the site tagline for the selective refresh partial.
- *
- * @return void
- */
+
 function creativoypunto_customize_partial_blogdescription() {
 	bloginfo( 'description' );
 }
 
-/**
- * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
- */
+
 function creativoypunto_customize_preview_js() {
 	wp_enqueue_script( 'creativoypunto-customizer', get_template_directory_uri() . '/js/customizer.js', array( 'customize-preview' ), _S_VERSION, true );
 }

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -1,21 +1,9 @@
 <?php
-/**
- * Jetpack Compatibility File
- *
- * @link https://jetpack.com/
- *
- * @package ProBroke
- */
 
-/**
- * Jetpack setup function.
- *
- * See: https://jetpack.com/support/infinite-scroll/
- * See: https://jetpack.com/support/responsive-videos/
- * See: https://jetpack.com/support/content-options/
- */
+
+
 function creativoypunto_jetpack_setup() {
-	// Add theme support for Infinite Scroll.
+	
 	add_theme_support(
 		'infinite-scroll',
 		array(
@@ -25,10 +13,10 @@ function creativoypunto_jetpack_setup() {
 		)
 	);
 
-	// Add theme support for Responsive Videos.
+	
 	add_theme_support( 'jetpack-responsive-videos' );
 
-	// Add theme support for Content Options.
+	
 	add_theme_support(
 		'jetpack-content-options',
 		array(
@@ -51,9 +39,7 @@ function creativoypunto_jetpack_setup() {
 add_action( 'after_setup_theme', 'creativoypunto_jetpack_setup' );
 
 if ( ! function_exists( 'creativoypunto_infinite_scroll_render' ) ) :
-	/**
-	 * Custom render function for Infinite Scroll.
-	 */
+	
 	function creativoypunto_infinite_scroll_render() {
 		while ( have_posts() ) {
 			the_post();

--- a/inc/menu-creativoypunto.php
+++ b/inc/menu-creativoypunto.php
@@ -1,8 +1,8 @@
 <?php
 
-// Menu Principal adaptacion a WordPress
 
-// bootstrap 5 wp_nav_menu walker
+
+
 class bootstrap_5_menu_creativoypunto extends Walker_Nav_menu {
 
 	private $current_item;
@@ -77,7 +77,7 @@ class bootstrap_5_menu_creativoypunto extends Walker_Nav_menu {
 	}
 }
 
-// register a new menu
+
 register_nav_menu( 'main-menu', 'Main menu' );
 
-// Fin Menu Principal adaptacion a WordPress
+

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -1,23 +1,14 @@
 <?php
-/**
- * Functions which enhance the theme by hooking into WordPress
- *
- * @package ProBroke
- */
 
-/**
- * Adds custom classes to the array of body classes.
- *
- * @param array $classes Classes for the body element.
- * @return array
- */
+
+
 function creativoypunto_body_classes( $classes ) {
-	// Adds a class of hfeed to non-singular pages.
+	
 	if ( ! is_singular() ) {
 		$classes[] = 'hfeed';
 	}
 
-	// Adds a class of no-sidebar when there is no sidebar present.
+	
 	if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 		$classes[] = 'no-sidebar';
 	}
@@ -26,9 +17,7 @@ function creativoypunto_body_classes( $classes ) {
 }
 add_filter( 'body_class', 'creativoypunto_body_classes' );
 
-/**
- * Add a pingback url auto-discovery header for single posts, pages, or attachments.
- */
+
 function creativoypunto_pingback_header() {
 	if ( is_singular() && pings_open() ) {
 		printf( '<link rel="pingback" href="%s">', esc_url( get_bloginfo( 'pingback_url' ) ) );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -1,16 +1,8 @@
 <?php
-/**
- * Custom template tags for this theme
- *
- * Eventually, some of the functionality here could be replaced by core features.
- *
- * @package ProBroke
- */
+
 
 if ( ! function_exists( 'creativoypunto_posted_on' ) ) :
-	/**
-	 * Prints HTML with meta information for the current post-date/time.
-	 */
+	
 	function creativoypunto_posted_on() {
 		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
 		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
@@ -26,51 +18,47 @@ if ( ! function_exists( 'creativoypunto_posted_on' ) ) :
 		);
 
 		$posted_on = sprintf(
-			/* translators: %s: post date. */
+			
 			esc_html_x( 'Posted on %s', 'post date', 'creativoypunto' ),
 			'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
 		);
 
-		echo '<span class="posted-on">' . $posted_on . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<span class="posted-on">' . $posted_on . '</span>'; 
 
 	}
 endif;
 
 if ( ! function_exists( 'creativoypunto_posted_by' ) ) :
-	/**
-	 * Prints HTML with meta information for the current author.
-	 */
+	
 	function creativoypunto_posted_by() {
 		$byline = sprintf(
-			/* translators: %s: post author. */
+			
 			esc_html_x( 'by %s', 'post author', 'creativoypunto' ),
 			'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
 		);
 
-		echo '<span class="byline"> ' . $byline . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '<span class="byline"> ' . $byline . '</span>'; 
 
 	}
 endif;
 
 if ( ! function_exists( 'creativoypunto_entry_footer' ) ) :
-	/**
-	 * Prints HTML with meta information for the categories, tags and comments.
-	 */
+	
 	function creativoypunto_entry_footer() {
-		// Hide category and tag text for pages.
+		
 		if ( 'post' === get_post_type() ) {
-			/* translators: used between list items, there is a space after the comma */
+			
 			$categories_list = get_the_category_list( esc_html__( ', ', 'creativoypunto' ) );
 			if ( $categories_list ) {
-				/* translators: 1: list of categories. */
-				printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'creativoypunto' ) . '</span>', $categories_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				
+				printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'creativoypunto' ) . '</span>', $categories_list ); 
 			}
 
-			/* translators: used between list items, there is a space after the comma */
+			
 			$tags_list = get_the_tag_list( '', esc_html_x( ', ', 'list item separator', 'creativoypunto' ) );
 			if ( $tags_list ) {
-				/* translators: 1: list of tags. */
-				printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'creativoypunto' ) . '</span>', $tags_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				
+				printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'creativoypunto' ) . '</span>', $tags_list ); 
 			}
 		}
 
@@ -79,7 +67,7 @@ if ( ! function_exists( 'creativoypunto_entry_footer' ) ) :
 			comments_popup_link(
 				sprintf(
 					wp_kses(
-						/* translators: %s: post title */
+						
 						__( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', 'creativoypunto' ),
 						array(
 							'span' => array(
@@ -96,7 +84,7 @@ if ( ! function_exists( 'creativoypunto_entry_footer' ) ) :
 		edit_post_link(
 			sprintf(
 				wp_kses(
-					/* translators: %s: Name of current post. Only visible to screen readers */
+					
 					__( 'Edit <span class="screen-reader-text">%s</span>', 'creativoypunto' ),
 					array(
 						'span' => array(
@@ -113,12 +101,7 @@ if ( ! function_exists( 'creativoypunto_entry_footer' ) ) :
 endif;
 
 if ( ! function_exists( 'creativoypunto_post_thumbnail' ) ) :
-	/**
-	 * Displays an optional post thumbnail.
-	 *
-	 * Wraps the post thumbnail in an anchor element on index views, or a div
-	 * element when on single views.
-	 */
+	
 	function creativoypunto_post_thumbnail() {
 		if ( post_password_required() || is_attachment() || ! has_post_thumbnail() ) {
 			return;
@@ -149,16 +132,12 @@ if ( ! function_exists( 'creativoypunto_post_thumbnail' ) ) :
 			</a>
 
 			<?php
-		endif; // End is_singular().
+		endif; 
 	}
 endif;
 
 if ( ! function_exists( 'wp_body_open' ) ) :
-	/**
-	 * Shim for sites older than 5.2.
-	 *
-	 * @link https://core.trac.wordpress.org/ticket/12563
-	 */
+	
 	function wp_body_open() {
 		do_action( 'wp_body_open' );
 	}

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -1,21 +1,7 @@
 <?php
-/**
- * WooCommerce Compatibility File
- *
- * @link https://woocommerce.com/
- *
- * @package ProBroke
- */
 
-/**
- * WooCommerce setup function.
- *
- * @link https://docs.woocommerce.com/document/third-party-custom-theme-compatibility/
- * @link https://github.com/woocommerce/woocommerce/wiki/Enabling-product-gallery-features-(zoom,-swipe,-lightbox)
- * @link https://github.com/woocommerce/woocommerce/wiki/Declaring-WooCommerce-support-in-themes
- *
- * @return void
- */
+
+
 function creativoypunto_woocommerce_setup() {
 	add_theme_support(
 		'woocommerce',
@@ -37,11 +23,7 @@ function creativoypunto_woocommerce_setup() {
 }
 add_action( 'after_setup_theme', 'creativoypunto_woocommerce_setup' );
 
-/**
- * WooCommerce specific scripts & stylesheets.
- *
- * @return void
- */
+
 function creativoypunto_woocommerce_scripts() {
 	wp_enqueue_style( 'creativoypunto-woocommerce-style', get_template_directory_uri() . '/woocommerce.css', array(), _S_VERSION );
 
@@ -61,22 +43,10 @@ function creativoypunto_woocommerce_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'creativoypunto_woocommerce_scripts' );
 
-/**
- * Disable the default WooCommerce stylesheet.
- *
- * Removing the default WooCommerce stylesheet and enqueing your own will
- * protect you during WooCommerce core updates.
- *
- * @link https://docs.woocommerce.com/document/disable-the-default-stylesheet/
- */
+
 add_filter( 'woocommerce_enqueue_styles', '__return_empty_array' );
 
-/**
- * Add 'woocommerce-active' class to the body tag.
- *
- * @param  array $classes CSS classes applied to the body tag.
- * @return array $classes modified to include 'woocommerce-active' class.
- */
+
 function creativoypunto_woocommerce_active_body_class( $classes ) {
 	$classes[] = 'woocommerce-active';
 
@@ -84,12 +54,7 @@ function creativoypunto_woocommerce_active_body_class( $classes ) {
 }
 add_filter( 'body_class', 'creativoypunto_woocommerce_active_body_class' );
 
-/**
- * Related Products Args.
- *
- * @param array $args related products args.
- * @return array $args related products args.
- */
+
 function creativoypunto_woocommerce_related_products_args( $args ) {
 	$defaults = array(
 		'posts_per_page' => 3,
@@ -102,20 +67,12 @@ function creativoypunto_woocommerce_related_products_args( $args ) {
 }
 add_filter( 'woocommerce_output_related_products_args', 'creativoypunto_woocommerce_related_products_args' );
 
-/**
- * Remove default WooCommerce wrapper.
- */
+
 remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10 );
 remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10 );
 
 if ( ! function_exists( 'creativoypunto_woocommerce_wrapper_before' ) ) {
-	/**
-	 * Before Content.
-	 *
-	 * Wraps all WooCommerce content in wrappers which match the theme markup.
-	 *
-	 * @return void
-	 */
+	
 	function creativoypunto_woocommerce_wrapper_before() {
 		?>
 			<main id="primary" class="site-main">
@@ -125,13 +82,7 @@ if ( ! function_exists( 'creativoypunto_woocommerce_wrapper_before' ) ) {
 add_action( 'woocommerce_before_main_content', 'creativoypunto_woocommerce_wrapper_before' );
 
 if ( ! function_exists( 'creativoypunto_woocommerce_wrapper_after' ) ) {
-	/**
-	 * After Content.
-	 *
-	 * Closes the wrapping divs.
-	 *
-	 * @return void
-	 */
+	
 	function creativoypunto_woocommerce_wrapper_after() {
 		?>
 			</main><!-- #main -->
@@ -140,27 +91,10 @@ if ( ! function_exists( 'creativoypunto_woocommerce_wrapper_after' ) ) {
 }
 add_action( 'woocommerce_after_main_content', 'creativoypunto_woocommerce_wrapper_after' );
 
-/**
- * Sample implementation of the WooCommerce Mini Cart.
- *
- * You can add the WooCommerce Mini Cart to header.php like so ...
- *
-	<?php
-		if ( function_exists( 'creativoypunto_woocommerce_header_cart' ) ) {
-			creativoypunto_woocommerce_header_cart();
-		}
-	?>
- */
+
 
 if ( ! function_exists( 'creativoypunto_woocommerce_cart_link_fragment' ) ) {
-	/**
-	 * Cart Fragments.
-	 *
-	 * Ensure cart contents update when products are added to the cart via AJAX.
-	 *
-	 * @param array $fragments Fragments to refresh via AJAX.
-	 * @return array Fragments to refresh via AJAX.
-	 */
+	
 	function creativoypunto_woocommerce_cart_link_fragment( $fragments ) {
 		ob_start();
 		creativoypunto_woocommerce_cart_link();
@@ -172,19 +106,13 @@ if ( ! function_exists( 'creativoypunto_woocommerce_cart_link_fragment' ) ) {
 add_filter( 'woocommerce_add_to_cart_fragments', 'creativoypunto_woocommerce_cart_link_fragment' );
 
 if ( ! function_exists( 'creativoypunto_woocommerce_cart_link' ) ) {
-	/**
-	 * Cart Link.
-	 *
-	 * Displayed a link to the cart including the number of items present and the cart total.
-	 *
-	 * @return void
-	 */
+	
 	function creativoypunto_woocommerce_cart_link() {
 		?>
 		<a class="cart-contents" href="<?php echo esc_url( wc_get_cart_url() ); ?>" title="<?php esc_attr_e( 'View your shopping cart', 'creativoypunto' ); ?>">
 			<?php
 			$item_count_text = sprintf(
-				/* translators: number of items in the mini cart. */
+				
 				_n( '%d item', '%d items', WC()->cart->get_cart_contents_count(), 'creativoypunto' ),
 				WC()->cart->get_cart_contents_count()
 			);
@@ -196,11 +124,7 @@ if ( ! function_exists( 'creativoypunto_woocommerce_cart_link' ) ) {
 }
 
 if ( ! function_exists( 'creativoypunto_woocommerce_header_cart' ) ) {
-	/**
-	 * Display Header Cart.
-	 *
-	 * @return void
-	 */
+	
 	function creativoypunto_woocommerce_header_cart() {
 		if ( is_cart() ) {
 			$class = 'current-menu-item';

--- a/index.php
+++ b/index.php
@@ -1,16 +1,5 @@
 <?php
-/**
- * The main template file
- *
- * This is the most generic template file in a WordPress theme
- * and one of the two required files for a theme (the other being style.css).
- * It is used to display a page when nothing more specific matches a query.
- * E.g., it puts together the home page when no home.php file exists.
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
- *
- * @package ProBroke
- */
+
 
 get_header();
 ?>
@@ -28,15 +17,11 @@ get_header();
 				<?php
 			endif;
 
-			/* Start the Loop */
+			
 			while ( have_posts() ) :
 				the_post();
 
-				/*
-				 * Include the Post-Type-specific template for the content.
-				 * If you want to override this in a child theme, then include a file
-				 * called content-___.php (where ___ is the Post Type name) and that will be used instead.
-				 */
+				
 				get_template_part( 'template-parts/content', get_post_type() );
 
 			endwhile;

--- a/page.php
+++ b/page.php
@@ -1,16 +1,5 @@
 <?php
-/**
- * The template for displaying all pages
- *
- * This is the template that displays all pages by default.
- * Please note that this is the WordPress construct of pages
- * and that other 'pages' on your WordPress site may use a
- * different template.
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
- *
- * @package ProBroke
- */
+
 
 get_header();
 ?>
@@ -23,12 +12,12 @@ get_header();
 
 			get_template_part( 'template-parts/content', 'page' );
 
-			// If comments are open or we have at least one comment, load up the comment template.
+			
 			if ( comments_open() || get_comments_number() ) :
 				comments_template();
 			endif;
 
-		endwhile; // End of the loop.
+		endwhile; 
 		?>
 
 	</main><!-- #main -->

--- a/search.php
+++ b/search.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * The template for displaying search results pages
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#search-result
- *
- * @package ProBroke
- */
+
 
 get_header();
 ?>
@@ -17,22 +11,18 @@ get_header();
 			<header class="page-header">
 				<h1 class="page-title">
 					<?php
-					/* translators: %s: search query. */
+					
 					printf( esc_html__( 'Search Results for: %s', 'creativoypunto' ), '<span>' . get_search_query() . '</span>' );
 					?>
 				</h1>
 			</header><!-- .page-header -->
 
 			<?php
-			/* Start the Loop */
+			
 			while ( have_posts() ) :
 				the_post();
 
-				/**
-				 * Run the loop for the search to output the results.
-				 * If you want to overload this in a child theme then include a file
-				 * called content-search.php and that will be used instead.
-				 */
+				
 				get_template_part( 'template-parts/content', 'search' );
 
 			endwhile;

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * The sidebar containing the main widget area
- *
- * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
- *
- * @package ProBroke
- */
+
 
 if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 	return;

--- a/single.php
+++ b/single.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * The template for displaying all single posts
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
- *
- * @package ProBroke
- */
+
 
 get_header();
 ?>
@@ -25,12 +19,12 @@ get_header();
 				)
 			);
 
-			// If comments are open or we have at least one comment, load up the comment template.
+			
 			if ( comments_open() || get_comments_number() ) :
 				comments_template();
 			endif;
 
-		endwhile; // End of the loop.
+		endwhile; 
 		?>
 
 	</main><!-- #main -->

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Template part for displaying a message that posts cannot be found
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
- *
- * @package ProBroke
- */
+
 
 ?>
 
@@ -20,7 +14,7 @@
 
 			printf(
 				'<p>' . wp_kses(
-					/* translators: 1: link to WP admin new post page. */
+					
 					__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'creativoypunto' ),
 					array(
 						'a' => array(

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Template part for displaying page content in page.php
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
- *
- * @package ProBroke
- */
+
 
 ?>
 
@@ -35,7 +29,7 @@
 			edit_post_link(
 				sprintf(
 					wp_kses(
-						/* translators: %s: Name of current post. Only visible to screen readers */
+						
 						__( 'Edit <span class="screen-reader-text">%s</span>', 'creativoypunto' ),
 						array(
 							'span' => array(

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Template part for displaying results in search pages
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
- *
- * @package ProBroke
- */
+
 
 ?>
 

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Template part for displaying posts
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
- *
- * @package ProBroke
- */
+
 
 ?>
 
@@ -36,7 +30,7 @@
 		the_content(
 			sprintf(
 				wp_kses(
-					/* translators: %s: Name of current post. Only visible to screen readers */
+					
 					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'creativoypunto' ),
 					array(
 						'span' => array(

--- a/under-construction.php
+++ b/under-construction.php
@@ -1,7 +1,5 @@
 <?php
-/*
-Template Name: Under Construction
-*/
+
 get_header(); ?>
 
 

--- a/yacht-functions.php
+++ b/yacht-functions.php
@@ -1,19 +1,15 @@
 <?php
-/**
- * Funciones específicas de la aplicación Yacht.
- *
- * @package YachtApp
- */
 
-// --------------------- JS AND CSS START ---------------------\\
+
+
 
 function app_yacht_scripts() {
-	// Verificar si estamos en el template correcto
+	
 	if ( is_page_template( 'app-yacht.php' ) ) {
-		// Array para dependencias comunes
+		
 		$dependencies = array();
 
-		// Registrar y encolar ini.js
+		
 		wp_enqueue_script(
 			'ini-script',
 			get_template_directory_uri() . '/app_yacht/shared/js/ini.js',
@@ -23,7 +19,7 @@ function app_yacht_scripts() {
 		);
 		$dependencies[] = 'ini-script';
 
-		// Registrar y encolar interfaz.js
+		
 		wp_enqueue_script(
 			'interfaz-script',
 			get_template_directory_uri() . '/app_yacht/modules/calc/js/interfaz.js',
@@ -33,7 +29,7 @@ function app_yacht_scripts() {
 		);
 		$dependencies[] = 'interfaz-script';
 
-		// Registrar y encolar validate.js
+		
 		wp_enqueue_script(
 			'validate-script',
 			get_template_directory_uri() . '/app_yacht/shared/js/validate.js',
@@ -43,7 +39,7 @@ function app_yacht_scripts() {
 		);
 		$dependencies[] = 'validate-script';
 
-		// Registrar y encolar mix.js
+		
 		wp_enqueue_script(
 			'mix-script',
 			get_template_directory_uri() . '/app_yacht/modules/calc/js/mix.js',
@@ -53,7 +49,7 @@ function app_yacht_scripts() {
 		);
 		$dependencies[] = 'mix-script';
 
-		// Registrar y encolar calculate.js
+		
 		wp_enqueue_script(
 			'calculator-script',
 			get_template_directory_uri() . '/app_yacht/modules/calc/js/calculate.js',
@@ -61,28 +57,28 @@ function app_yacht_scripts() {
 			'1.0.0',
 			true
 		);
-		// Localizar datos para mix.js
+		
 		wp_localize_script(
 			'mix-script',
 			'ajaxData',
 			array(
 				'ajaxurl' => admin_url( 'admin-ajax.php' ),
-				'nonce'   => wp_create_nonce( 'mix_calculate_nonce' ), // Nonce para handle_calculate_mix
+				'nonce'   => wp_create_nonce( 'mix_calculate_nonce' ), 
 			)
 		);
-		// Localizar datos para calculate.js
+		
 		wp_localize_script(
 			'calculator-script',
 			'ajaxCalculatorData',
 			array(
 				'ajaxurl' => admin_url( 'admin-ajax.php' ),
-				'nonce'   => wp_create_nonce( 'calculate_nonce' ), // Nonce para seguridad
+				'nonce'   => wp_create_nonce( 'calculate_nonce' ), 
 			)
 		);
 
-		// *********** Se elimina calculate-template.js (ya no se usa) ***********
+		
 
-		// Generador de templates (Módulo Template principal)
+		
 		wp_enqueue_script(
 			'template-script',
 			get_template_directory_uri() . '/app_yacht/modules/template/js/template.js',
@@ -91,17 +87,17 @@ function app_yacht_scripts() {
 			true
 		);
 
-		// Localizar datos para template.js
+		
 		wp_localize_script(
 			'template-script',
 			'ajaxTemplateData',
 			array(
 				'ajaxurl' => admin_url( 'admin-ajax.php' ),
-				'nonce'   => wp_create_nonce( 'template_nonce' ), // Nonce para seguridad
+				'nonce'   => wp_create_nonce( 'template_nonce' ), 
 			)
 		);
 
-		// ***************** Módulo de correo (mail.js) ***************** //
+		
 		wp_enqueue_script(
 			'mail-script',
 			get_template_directory_uri() . '/app_yacht/modules/mail/mail.js',
@@ -109,7 +105,7 @@ function app_yacht_scripts() {
 			'1.0.0',
 			true
 		);
-		// Localizar datos para mail.js si fuera necesario
+		
 		wp_localize_script(
 			'mail-script',
 			'ajaxMailData',
@@ -123,7 +119,7 @@ function app_yacht_scripts() {
 add_action( 'wp_enqueue_scripts', 'app_yacht_scripts' );
 
 function app_yacht_css() {
-	// Verificar si estamos en el template correcto
+	
 	if ( is_page_template( 'app-yacht.php' ) ) {
 		wp_enqueue_style(
 			'app-yacht-styles',
@@ -132,7 +128,7 @@ function app_yacht_css() {
 			'1.0.0'
 		);
 
-		// CSS de Mail
+		
 		wp_enqueue_style(
 			'mail-styles',
 			get_template_directory_uri() . '/app_yacht/modules/mail/mail.css',
@@ -143,43 +139,43 @@ function app_yacht_css() {
 }
 add_action( 'wp_enqueue_scripts', 'app_yacht_css' );
 
-// --------------------- JS AND CSS END ---------------------\\
 
 
-// --------------------- CARGA DINAMICA DE ARCHIVOS START ---------------------\\
 
-// Cargar archivos solo si se usa la plantilla o en AJAX
+
+
+
 if ( is_page_template( 'app-yacht.php' ) || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) {
-	// Calculadoras
+	
 	require_once get_template_directory() . '/app_yacht/modules/calc/php/calculatemix.php';
 	require_once get_template_directory() . '/app_yacht/modules/calc/php/calculate.php';
 
-	// Templates
+	
 	require_once get_template_directory() . '/app_yacht/modules/template/php/load-template.php';
 	require_once get_template_directory() . '/app_yacht/modules/template/php/template-data.php';
 
-	// El módulo de correo se carga desde core/app-yacht.php.
+	
 }
 
-// Registrar las acciones AJAX globalmente
-// ARCHIVO: /app_yacht/modules/calc/php/calculate.php
+
+
 add_action( 'wp_ajax_calculate_charter', 'handle_calculate_charter' );
 add_action( 'wp_ajax_nopriv_calculate_charter', 'handle_calculate_charter' );
 
-// ARCHIVO calculatemix.php
+
 add_action( 'wp_ajax_calculate_mix', 'handle_calculate_mix' );
 add_action( 'wp_ajax_nopriv_calculate_mix', 'handle_calculate_mix' );
 
-// ARCHIVO load-template.php
+
 add_action( 'wp_ajax_load_template_preview', 'handle_load_template_preview' );
 add_action( 'wp_ajax_nopriv_load_template_preview', 'handle_load_template_preview' );
 add_action( 'wp_ajax_createTemplate', 'handle_create_template' );
 add_action( 'wp_ajax_nopriv_createTemplate', 'handle_create_template' );
 
-// --------------------- CARGA DINAMICA DE ARCHIVOS END ---------------------\\
 
 
-// --------------------- REGISTROS DE EMAIL ---------------------\\
+
+
 add_filter(
 	'wp_mail',
 	function( $args ) {


### PR DESCRIPTION
## Summary
- strip all PHP comments and docblocks to eliminate outdated documentation

## Testing
- `composer lint:php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f37997088832983eeb858836f161e