### PR TITLE
Remove development console logs

### DIFF
--- a/app_yacht/modules/calc/js/interfaz.js
+++ b/app_yacht/modules/calc/js/interfaz.js
@@ -458,7 +458,6 @@ function updateUIConstraints() {
 
 // --- Función de Inicialización del Módulo ---
 function initCalcInterface() {
-    console.log("Inicializando interfaz de calculadora...");
     // Check si funciones compartidas existen
     if (!window.toggleContainer || !window.addDynamicField || !window.removeDynamicField) {
         console.warn('Las funciones UI compartidas (toggleContainer, addDynamicField, removeDynamicField) no están disponibles.');
@@ -500,7 +499,6 @@ function initCalcInterface() {
          // addGuestFeeBtn.addEventListener('click', addExtraPerPersonField);
      }
      
-     console.log("Interfaz de calculadora inicializada.");
 }
 
 // --- Ejecución de Inicialización ---

--- a/app_yacht/modules/mail/mail-hidden-fields.js
+++ b/app_yacht/modules/mail/mail-hidden-fields.js
@@ -36,6 +36,5 @@
         
         // Añadir el contenedor al DOM
         mailContainer.appendChild(hiddenContainer);
-        console.log('Campos ocultos para storage.js creados');
     });
 })();

--- a/app_yacht/modules/mail/mail.js
+++ b/app_yacht/modules/mail/mail.js
@@ -71,7 +71,7 @@ function restoreFormContent() {
 
 (function($){
     $(document).ready(function() {
-        console.log("Módulo Mail cargado correctamente.");
+        
         
         // Inicializar el compositor de correo
         mailComposer = new MailComposer({
@@ -98,7 +98,6 @@ function restoreFormContent() {
         // Conectar con el sistema de eventos si está disponible
         if (typeof window.eventBus !== 'undefined') {
             window.eventBus.subscribe('template:created', (data) => {
-                console.log('Plantilla creada, actualizando editor de correo:', data);
                 // Aquí puedes añadir lógica para actualizar el editor con datos de la plantilla
             });
         }

--- a/app_yacht/modules/mail/outlook/outlook-ajax.js
+++ b/app_yacht/modules/mail/outlook/outlook-ajax.js
@@ -1,7 +1,6 @@
 // Archivo modules\mail\outlook\outlook-ajax.js
 (function($){
     $(document).ready(function() {
-        console.log("outlook-ajax.js cargado.");
         
         // loadGoogleFontsAPI() eliminada - no usar Google Fonts en email.
         
@@ -12,7 +11,7 @@
         if (typeof pbOutlookData === 'undefined') {
             console.error('Error: La variable pbOutlookData no está definida. Asegúrate de que yacht-functions.php está cargando correctamente.');
         } else {
-            console.log('pbOutlookData está disponible:', pbOutlookData);
+            
         }
         
         // Verificar si hay parámetro outlook=success en la URL y mostrar mensaje

--- a/app_yacht/modules/mail/signature/msp-signature.js
+++ b/app_yacht/modules/mail/signature/msp-signature.js
@@ -1,5 +1,4 @@
 jQuery(document).ready(function($){
-    console.log("msp-signature.js loaded.");
 
     // 1) Intercept paste en #mspEditor
     $("#mspEditor").on("paste", function(e){

--- a/app_yacht/modules/template/js/template.js
+++ b/app_yacht/modules/template/js/template.js
@@ -209,7 +209,6 @@ function restoreTemplateFormData() {
     });
     
     if (savedData) {
-        console.log('Datos del formulario de plantilla restaurados (SIN extras):', savedData);
         
         // Limpiar contenedor de extras explícitamente al restaurar
         const extrasContainer = document.getElementById('extrasContainer');
@@ -253,10 +252,8 @@ function restoreTemplateFormData() {
 
 // Callbacks para los eventos de TemplateManager
 function handleTemplateCreated(data) {
-    console.log('Plantilla creada correctamente:', data);
 }
 function handleTemplateLoaded(data) {
-    console.log('Plantilla cargada correctamente:', data);
 }
 function handleTemplateError(error) {
     console.error('Error en la plantilla:', error);

--- a/app_yacht/shared/js/classes/MailComposer.js
+++ b/app_yacht/shared/js/classes/MailComposer.js
@@ -37,10 +37,7 @@ class MailComposer {
         // Inicializar sistema de eventos si está disponible
         if (typeof window.eventBus !== 'undefined') {
             this.eventBus = window.eventBus;
-            console.log('EventBus conectado a MailComposer');
         }
-        
-        console.log('MailComposer inicializado');
     }
     
     /**
@@ -85,7 +82,6 @@ class MailComposer {
                         document.getElementById('selected_font').value = selectedFont;
                     }
                 });
-                console.log('Fuente seleccionada guardada:', selectedFont);
                 
                 // Aplicar la fuente al selector para previsualización
                 e.target.style.fontFamily = selectedFont;
@@ -119,7 +115,6 @@ class MailComposer {
         this.updateFontSelector([]); 
         this.restoreSelectedFont();
         
-        console.log('Editor inicializado correctamente');
     }
     
     /**
@@ -248,7 +243,6 @@ class MailComposer {
              if (Array.from(fontSelect.options).some(option => option.value === savedFont)) {
                 fontSelect.value = savedFont;
                 fontSelect.style.fontFamily = savedFont;
-                console.log('Fuente restaurada desde localStorage:', savedFont);
             } else {
                  console.warn('Fuente guardada "' + savedFont + '" no encontrada en el selector.');
             }

--- a/app_yacht/shared/js/classes/TemplateManager.js
+++ b/app_yacht/shared/js/classes/TemplateManager.js
@@ -39,10 +39,7 @@ class TemplateManager {
         // Inicializar sistema de eventos si está disponible
         if (typeof window.eventBus !== 'undefined') {
             this.eventBus = window.eventBus;
-            console.log('EventBus conectado a TemplateManager');
         }
-        
-        console.log('TemplateManager inicializado');
     }
     
     /**


### PR DESCRIPTION
## Summary
- remove unneeded console logging from calculator interface
- silence TemplateManager and template form restoration
- drop initialization logs from mail-related scripts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint:js` *(fails: wp-scripts: not found)*
- `npm install` *(fails: Build failed with error code: 1)
- `npx eslint app_yacht/modules/calc/js/interfaz.js` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_688f41beeda483299359b1e63ed43af0