### PR TITLE
Add nonce verification for yacht AJAX handlers

### DIFF
--- a/app_yacht/core/bootstrap.php
+++ b/app_yacht/core/bootstrap.php
@@ -126,60 +126,96 @@ class AppYachtBootstrap {
 	}
 	
 	
-	public static function handleCalculateCharter() {
-		try {
-			$calcService = self::getContainer()->get( 'calc_service' );
-			$result      = $calcService->calculateCharter( $_POST );
-			wp_send_json_success( $result );
-		} catch ( Exception $e ) {
-			error_log( 'Calculate Charter Error: ' . $e->getMessage() );
-			wp_send_json_error( 'Error en cálculo: ' . $e->getMessage() );
-		}
-	}
+        public static function handleCalculateCharter() {
+                try {
+                        $nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( $_POST['nonce'] ) : '';
+                        if ( ! $nonce || ! wp_verify_nonce( $nonce, 'calculate_nonce' ) ) {
+                                wp_send_json_error( array(
+                                        'message' => 'Security check failed',
+                                        'code'    => 'security_error',
+                                ) );
+                                return;
+                        }
+
+                        $calcService = self::getContainer()->get( 'calc_service' );
+                        $result      = $calcService->calculateCharter( $_POST );
+                        wp_send_json_success( $result );
+                } catch ( Exception $e ) {
+                        error_log( 'Calculate Charter Error: ' . $e->getMessage() );
+                        wp_send_json_error( 'Error en cálculo: ' . $e->getMessage() );
+                }
+        }
 	
 	
-	public static function handleCalculateMix() {
-		try {
-			$calcService = self::getContainer()->get( 'calc_service' );
-			$result      = $calcService->calculateMix( $_POST );
-			wp_send_json_success( $result );
-		} catch ( Exception $e ) {
-			error_log( 'Calculate Mix Error: ' . $e->getMessage() );
-			wp_send_json_error( 'Error en cálculo mix: ' . $e->getMessage() );
-		}
-	}
+        public static function handleCalculateMix() {
+                try {
+                        $nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( $_POST['nonce'] ) : '';
+                        if ( ! $nonce || ! wp_verify_nonce( $nonce, 'mix_calculate_nonce' ) ) {
+                                wp_send_json_error( array(
+                                        'message' => 'Security check failed',
+                                        'code'    => 'security_error',
+                                ) );
+                                return;
+                        }
+
+                        $calcService = self::getContainer()->get( 'calc_service' );
+                        $result      = $calcService->calculateMix( $_POST );
+                        wp_send_json_success( $result );
+                } catch ( Exception $e ) {
+                        error_log( 'Calculate Mix Error: ' . $e->getMessage() );
+                        wp_send_json_error( 'Error en cálculo mix: ' . $e->getMessage() );
+                }
+        }
 	
 	
-	public static function handleLoadTemplatePreview() {
-		try {
-			$renderEngine = self::getContainer()->get( 'render_engine' );
-			$result       = $renderEngine->loadTemplatePreview( $_POST );
-			wp_send_json_success( $result );
-		} catch ( Exception $e ) {
-			error_log( 'Load Template Preview Error: ' . $e->getMessage() );
-			wp_send_json_error( 'Error cargando template: ' . $e->getMessage() );
-		}
-	}
+        public static function handleLoadTemplatePreview() {
+                try {
+                        $nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( $_POST['nonce'] ) : '';
+                        if ( ! $nonce || ! wp_verify_nonce( $nonce, 'template_nonce' ) ) {
+                                wp_send_json_error( array(
+                                        'message' => 'Security check failed',
+                                        'code'    => 'security_error',
+                                ) );
+                                return;
+                        }
+
+                        $renderEngine = self::getContainer()->get( 'render_engine' );
+                        $result       = $renderEngine->loadTemplatePreview( $_POST );
+                        wp_send_json_success( $result );
+                } catch ( Exception $e ) {
+                        error_log( 'Load Template Preview Error: ' . $e->getMessage() );
+                        wp_send_json_error( 'Error cargando template: ' . $e->getMessage() );
+                }
+        }
 	
-	
-	public static function handleCreateTemplate() {
-		try {
-			$renderEngine     = self::getContainer()->get( 'render_engine' );
-			$yachtInfoService = self::getContainer()->get( 'yacht_info_service' );
-			
-			
-			$yachtData = null;
-			if ( ! empty( $_POST['yachtUrl'] ) ) {
-				$yachtData = $yachtInfoService->extractYachtInfo( $_POST['yachtUrl'] );
-			}
-			
-			$result = $renderEngine->createTemplate( $_POST, $yachtData );
-			wp_send_json_success( $result );
-		} catch ( Exception $e ) {
-			error_log( 'Create Template Error: ' . $e->getMessage() );
-			wp_send_json_error( 'Error creando template: ' . $e->getMessage() );
-		}
-	}
+
+        public static function handleCreateTemplate() {
+                try {
+                        $nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( $_POST['nonce'] ) : '';
+                        if ( ! $nonce || ! wp_verify_nonce( $nonce, 'template_nonce' ) ) {
+                                wp_send_json_error( array(
+                                        'message' => 'Security check failed',
+                                        'code'    => 'security_error',
+                                ) );
+                                return;
+                        }
+
+                        $renderEngine     = self::getContainer()->get( 'render_engine' );
+                        $yachtInfoService = self::getContainer()->get( 'yacht_info_service' );
+
+
+                        $yachtData = null;
+                        if ( ! empty( $_POST['yachtUrl'] ) ) {
+                                $yachtData = $yachtInfoService->extractYachtInfo( $_POST['yachtUrl'] );
+                        }
+
+                        $result = $renderEngine->createTemplate( $_POST, $yachtData );
+                        wp_send_json_success( $result );
+                } catch ( Exception $e ) {
+                        error_log( 'Create Template Error: ' . $e->getMessage() );
+                        wp_send_json_error( 'Error creando template: ' . $e->getMessage() );
+                }
+        }
 	
 	public static function handleExtractYachtInfo() {
 		try {

--- a/app_yacht/modules/calc/js/calculate.js
+++ b/app_yacht/modules/calc/js/calculate.js
@@ -48,7 +48,7 @@ async function handleCalculateButtonClick() {
         // Crear FormData
         const formData = new FormData();
         formData.append('action', 'calculate_charter');
-        formData.append('nonce', ajaxCalculatorData.nonce);
+        formData.append('nonce', ajaxCalculatorData?.nonce || '');
 
         // Recolectar currency
         const currency = document.getElementById('currency')?.value || '';

--- a/app_yacht/modules/calc/js/mix.js
+++ b/app_yacht/modules/calc/js/mix.js
@@ -319,7 +319,7 @@ function applyMix() {
     // Crear FormData
     const formData = new FormData();
     formData.append('action', 'calculate_mix');
-    formData.append('nonce', ajaxData.nonce); // Añadir nonce para seguridad CSRF
+    formData.append('nonce', ajaxData?.nonce || ''); // Añadir nonce para seguridad CSRF
     formData.append('mixnights', mixNights);
     formData.append('lowSeasonRate', lowSeasonRate);
     formData.append('lowSeasonNights', lowSeasonNights);

--- a/app_yacht/shared/js/classes/TemplateManager.js
+++ b/app_yacht/shared/js/classes/TemplateManager.js
@@ -49,7 +49,7 @@ class TemplateManager {
     collectFormData() {
         const formData = new FormData();
         formData.append('action', 'createTemplate');
-        formData.append('nonce', this.config.nonce);
+        formData.append('nonce', this.config?.nonce || '');
         
         // Recolectar URL del yate
         const yachtUrl = document.getElementById('yacht-url')?.value.trim() || '';
@@ -326,7 +326,7 @@ class TemplateManager {
             // Crear FormData para la petición
             const formData = new FormData();
             formData.append('action', 'load_template');
-            formData.append('nonce', this.config.nonce);
+            formData.append('nonce', this.config?.nonce || '');
             formData.append('templateId', templateId);
             
             // Enviar petición usando fetch con async/await


### PR DESCRIPTION
## Summary
- verify nonces in charter, mix, template preview and template creation handlers
- send security error JSON when nonce validation fails
- include nonce in front-end AJAX requests for calculator, mix and template manager

## Testing
- `php -l app_yacht/core/bootstrap.php`
- `node --check app_yacht/modules/calc/js/calculate.js`
- `node --check app_yacht/modules/calc/js/mix.js`
- `node --check app_yacht/shared/js/classes/TemplateManager.js`


------
https://chatgpt.com/codex/tasks/task_e_68922b6069e48329a497f243910df058