### PR TITLE
Handle Outlook attachment errors and document return types

### DIFF
--- a/app_yacht/modules/mail/mail-service.php
+++ b/app_yacht/modules/mail/mail-service.php
@@ -31,7 +31,6 @@ class MailService implements MailServiceInterface {
 				return $validation;
 			}
 			
-			
 			$data = ValidatorHelper::sanitizeInputData( $data );
 			
 			
@@ -61,7 +60,10 @@ class MailService implements MailServiceInterface {
 			
 			
 			$outlookData = $this->prepareOutlookData( $data, $userId );
-			
+			if ( is_wp_error( $outlookData ) ) {
+				return $outlookData;
+			}
+
 			
 			$result = pb_outlook_send_mail( $outlookData, $userId );
 			
@@ -252,9 +254,13 @@ class MailService implements MailServiceInterface {
 		}
 		
 		
-		if ( ! empty( $data['attachments'] ) ) {
-			$outlookData['attachments'] = $this->processAttachments( $data['attachments'] );
-		}
+                if ( ! empty( $data['attachments'] ) ) {
+                        $attachments = $this->processAttachments( $data['attachments'] );
+                        if ( is_wp_error( $attachments ) ) {
+                                return $attachments;
+                        }
+                        $outlookData['attachments'] = $attachments;
+                }
 		
 		return $outlookData;
 	}

--- a/app_yacht/shared/interfaces/mail-service-interface.php
+++ b/app_yacht/shared/interfaces/mail-service-interface.php
@@ -9,9 +9,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 interface MailServiceInterface {
 
 	
+	/**
+	 * Send an email using the configured method.
+	 *
+	 * @param array $data Email data.
+	 * @return bool|WP_Error True on success or WP_Error on failure.
+	 */
 	public function sendEmail( array $data);
 
 	
+	/**
+	 * Send an email through Outlook integration.
+	 *
+	 * @param array $data   Email data.
+	 * @param int   $userId User ID.
+	 * @return bool|WP_Error True on success or WP_Error on failure.
+	 */
 	public function sendEmailViaOutlook( array $data, $userId);
 
 	
@@ -27,6 +40,12 @@ interface MailServiceInterface {
 	public function validateEmailData( array $data);
 
 	
+	/**
+	 * Process attachments before sending emails.
+	 *
+	 * @param array $attachments Attachments data.
+	 * @return array|WP_Error Processed attachments or WP_Error on failure.
+	 */
 	public function processAttachments( array $attachments);
 
 	


### PR DESCRIPTION
## Summary
- Validate attachment processing before sending Outlook emails.
- Document MailServiceInterface methods to reflect WP_Error returns.

## Testing
- `composer lint:php`
- `composer lint:wpcs` *(fails: WordPress coding standards warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689231ba48b08329874d533fd12a9d14