### PR TITLE
feat(calc): add relocation fee auto mini-calculator

### DIFF
--- a/app_yacht/core/bootstrap.php
+++ b/app_yacht/core/bootstrap.php
@@ -104,8 +104,12 @@ class AppYachtBootstrap {
 		add_action( 'wp_ajax_calculate_charter', array( __CLASS__, 'handleCalculateCharter' ) );
 		add_action( 'wp_ajax_nopriv_calculate_charter', array( __CLASS__, 'handleCalculateCharter' ) );
 		
-		add_action( 'wp_ajax_calculate_mix', array( __CLASS__, 'handleCalculateMix' ) );
-		add_action( 'wp_ajax_nopriv_calculate_mix', array( __CLASS__, 'handleCalculateMix' ) );
+                add_action( 'wp_ajax_calculate_mix', array( __CLASS__, 'handleCalculateMix' ) );
+                add_action( 'wp_ajax_nopriv_calculate_mix', array( __CLASS__, 'handleCalculateMix' ) );
+
+                // Minicalculadora de relocation
+                add_action( 'wp_ajax_calculate_relocation', array( __CLASS__, 'handleCalculateRelocation' ) );
+                add_action( 'wp_ajax_nopriv_calculate_relocation', array( __CLASS__, 'handleCalculateRelocation' ) );
 		
 		add_action( 'wp_ajax_load_template_preview', array( __CLASS__, 'handleLoadTemplatePreview' ) );
 		add_action( 'wp_ajax_nopriv_load_template_preview', array( __CLASS__, 'handleLoadTemplatePreview' ) );
@@ -164,6 +168,21 @@ class AppYachtBootstrap {
                 } catch ( Exception $e ) {
                         error_log( 'Calculate Mix Error: ' . $e->getMessage() );
                         wp_send_json_error( 'Error en cálculo mix: ' . $e->getMessage() );
+                }
+        }
+
+        public static function handleCalculateRelocation() {
+                try {
+                        $nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( $_POST['nonce'] ) : '';
+                        if ( ! $nonce || ! wp_verify_nonce( $nonce, 'relocation_calculate_nonce' ) ) {
+                                wp_send_json_error( array( 'message' => 'Security check failed', 'code' => 'security_error' ) );
+                                return;
+                        }
+                        // Incluir el script de cálculo
+                        include_once __DIR__ . '/../modules/calc/php/calculateRelocation.php';
+                } catch ( Exception $e ) {
+                        error_log( 'Calculate Relocation Error: ' . $e->getMessage() );
+                        wp_send_json_error( 'Error en cálculo de relocation: ' . $e->getMessage() );
                 }
         }
 	

--- a/app_yacht/modules/calc/calculator.php
+++ b/app_yacht/modules/calc/calculator.php
@@ -121,17 +121,66 @@
 						</div>
 					</div>
 					<!-- Security Deposit Field -->
-					<div id="securityField" class="form-group optional-field-container col-3" style="display: none;">
-						<label>Security Deposit:</label>
-						<div class="input-group" style="flex-wrap: nowrap;">
-							<input type="text" class="form-control" id="securityFee" name="securityFee" placeholder="Security fee" oninput="formatNumber(this)" required>
-							<span class="input-group-text" id="securityCurrencySymbol">€</span>
-						</div>
-					</div>
-				</div>
+                                        <div id="securityField" class="form-group optional-field-container col-3" style="display: none;">
+                                                <label>Security Deposit:</label>
+                                                <div class="input-group" style="flex-wrap: nowrap;">
+                                                        <input type="text" class="form-control" id="securityFee" name="securityFee" placeholder="Security fee" oninput="formatNumber(this)" required>
+                                                        <span class="input-group-text" id="securityCurrencySymbol">€</span>
+                                                </div>
+                                        </div>
+                                </div>
 
-				<!-- Extra Fields Container -->
-				<div id="extrasContainer" class="row optional-fields mt-2"></div>
+                                <!-- Activador de la minicalculadora -->
+                                <div class="form-check form-switch mt-2">
+                                        <input id="relocationAutoCheck" type="checkbox" class="form-check-input" aria-controls="relocationAutoContainer">
+                                        <label class="form-check-label" for="relocationAutoCheck">Relocation Fee auto</label>
+                                </div>
+
+                                <!-- Contenedor de la minicalculadora (oculto por defecto) -->
+                                <div id="relocationAutoContainer" class="mt-3" style="display:none;">
+                                        <p class="fw-bold mb-2">Calculadora de relocation</p>
+                                        <div class="row">
+                                                <div class="col-4">
+                                                        <input id="reloc-distance-check" type="checkbox"> Distancia (NM)
+                                                        <input id="reloc-distance" type="number" class="form-control mt-1" placeholder="Distancia" />
+                                                </div>
+                                                <div class="col-4">
+                                                        <input id="reloc-hours-check" type="checkbox"> Horas
+                                                        <input id="reloc-hours" type="number" class="form-control mt-1" placeholder="Horas" />
+                                                </div>
+                                                <div class="col-4">
+                                                        <input id="reloc-fuel-consumption-check" type="checkbox"> Consumo (l/h o l/nm)
+                                                        <input id="reloc-fuel-consumption" type="number" class="form-control mt-1" placeholder="Consumo" />
+                                                </div>
+                                                <div class="col-4">
+                                                        <input id="reloc-fuel-price-check" type="checkbox"> Precio combustible
+                                                        <input id="reloc-fuel-price" type="number" step="0.01" class="form-control mt-1" placeholder="€/L" />
+                                                </div>
+                                                <div class="col-4">
+                                                        <input id="reloc-crew-count-check" type="checkbox"> Tripulación
+                                                        <input id="reloc-crew-count" type="number" class="form-control mt-1" placeholder="N.º tripulantes" />
+                                                </div>
+                                                <div class="col-4">
+                                                        <input id="reloc-crew-wage-check" type="checkbox"> Salario diario
+                                                        <input id="reloc-crew-wage" type="number" step="0.01" class="form-control mt-1" placeholder="€/día" />
+                                                </div>
+                                                <div class="col-4">
+                                                        <input id="reloc-port-fees-check" type="checkbox"> Tasas portuarias
+                                                        <input id="reloc-port-fees" type="number" step="0.01" class="form-control mt-1" placeholder="€" />
+                                                </div>
+                                                <div class="col-4">
+                                                        <input id="reloc-extra-check" type="checkbox"> Otros gastos
+                                                        <input id="reloc-extra" type="number" step="0.01" class="form-control mt-1" placeholder="€" />
+                                                </div>
+                                        </div>
+                                        <div class="mt-2">
+                                                <button id="applyRelocationButton" type="button" class="btn btn-secondary">Aplicar</button>
+                                                <span id="relocation-auto-result" class="ms-3 fw-bold"></span>
+                                        </div>
+                                </div>
+
+                                <!-- Extra Fields Container -->
+                                <div id="extrasContainer" class="row optional-fields mt-2"></div>
 
 				<!-- Error Message -->
 				<div id="errorMessage" class="text-danger" style="display: none;" role="alert" aria-live="assertive">Please fill in all required fields.</div>
@@ -208,4 +257,11 @@
 	<script src="<?php echo get_template_directory_uri(); ?>/app_yacht/modules/calc/js/mix.js"></script>
 	<script src="<?php echo get_template_directory_uri(); ?>/app_yacht/modules/calc/js/extraPerPerson.js"></script>
 	<script src="<?php echo get_template_directory_uri(); ?>/app_yacht/modules/calc/js/calculate.js"></script>
-	<script src="<?php echo get_template_directory_uri(); ?>/app_yacht/modules/calc/js/promotion.js"></script>
+        <script src="<?php echo get_template_directory_uri(); ?>/app_yacht/modules/calc/js/promotion.js"></script>
+        <script src="<?php echo get_template_directory_uri(); ?>/app_yacht/modules/calc/js/relocationAuto.js"></script>
+        <script>
+        window.ajaxRelocationData = {
+            ajaxurl: ajaxCalculatorData.ajaxurl,
+            nonce: '<?php echo wp_create_nonce( 'relocation_calculate_nonce' ); ?>'
+        };
+        </script>

--- a/app_yacht/modules/calc/js/relocationAuto.js
+++ b/app_yacht/modules/calc/js/relocationAuto.js
@@ -1,0 +1,111 @@
+/*
+ * relocationAuto.js
+ *
+ * Este módulo implementa una minicalculadora para la "Relocation Fee".
+ * Al activar la casilla "Relocation Fee auto", se muestran campos de entrada
+ * configurables (distancia, consumo, precio combustible, tripulación, etc.).
+ * El módulo toma valores predeterminados del objeto global `yachtInfoData` si existe,
+ * permitiendo al usuario modificarlos. Al pulsar "Aplicar", se envía una petición
+ * AJAX al endpoint `calculate_relocation` que devuelve la tarifa calculada y
+ * la inyecta en el campo `relocationFee` de la calculadora principal.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    const autoCheckbox = document.getElementById('relocationAutoCheck');
+    const autoContainer = document.getElementById('relocationAutoContainer');
+
+    if (autoCheckbox && autoContainer) {
+        // Mostrar u ocultar la calculadora según el estado del checkbox
+        autoCheckbox.addEventListener('change', () => {
+            autoContainer.style.display = autoCheckbox.checked ? 'block' : 'none';
+            // Al mostrar el contenedor, precargar valores si están disponibles
+            if (autoCheckbox.checked) {
+                prefillRelocationFields();
+            }
+        });
+    }
+
+    // Manejar clic en el botón de aplicar
+    const applyButton = document.getElementById('applyRelocationButton');
+    if (applyButton) {
+        applyButton.addEventListener('click', () => {
+            calculateRelocation();
+        });
+    }
+});
+
+/**
+ * Precarga valores en los campos de la calculadora usando la información
+ * disponible en `window.yachtInfoData`. Si no existe, se dejan vacíos.
+ */
+function prefillRelocationFields() {
+    const data = window.yachtInfoData || {};
+    const fuelConsumption = document.getElementById('reloc-fuel-consumption');
+    const cruisingSpeed   = document.getElementById('reloc-cruising-speed');
+    const crewCount       = document.getElementById('reloc-crew-count');
+    if (fuelConsumption && data.fuelConsumption && fuelConsumption.value === '') {
+        fuelConsumption.value = data.fuelConsumption;
+    }
+    if (cruisingSpeed && data.cruisingSpeed && cruisingSpeed.value === '') {
+        cruisingSpeed.value = data.cruisingSpeed;
+    }
+    if (crewCount && data.crew && crewCount.value === '') {
+        crewCount.value = data.crew;
+    }
+}
+
+/**
+ * Recolecta los valores de los campos seleccionados y realiza una solicitud
+ * AJAX al servidor para calcular la Relocation Fee. El resultado se inserta
+ * en el campo `relocationFee` de la calculadora principal.
+ */
+function calculateRelocation() {
+    // Crear objeto con los datos seleccionados
+    const params = {};
+    // Solo incluir campos marcados por el usuario
+    const fields = [
+        { checkboxId: 'reloc-distance-check', inputId: 'reloc-distance', name: 'distance' },
+        { checkboxId: 'reloc-hours-check',    inputId: 'reloc-hours',    name: 'hours' },
+        { checkboxId: 'reloc-fuel-consumption-check', inputId: 'reloc-fuel-consumption', name: 'fuelConsumption' },
+        { checkboxId: 'reloc-fuel-price-check', inputId: 'reloc-fuel-price', name: 'fuelPrice' },
+        { checkboxId: 'reloc-crew-count-check', inputId: 'reloc-crew-count', name: 'crewCount' },
+        { checkboxId: 'reloc-crew-wage-check', inputId: 'reloc-crew-wage', name: 'crewWage' },
+        { checkboxId: 'reloc-port-fees-check', inputId: 'reloc-port-fees', name: 'portFees' },
+        { checkboxId: 'reloc-extra-check', inputId: 'reloc-extra', name: 'extraCosts' }
+    ];
+    fields.forEach(field => {
+        const chk = document.getElementById(field.checkboxId);
+        const input = document.getElementById(field.inputId);
+        if (chk && chk.checked && input) {
+            params[field.name] = input.value;
+        }
+    });
+    // Moneda (para formatear la respuesta)
+    const currency = document.getElementById('currency')?.value || '€';
+    params.currency = currency;
+    // Añadir nonce de seguridad si existe
+    params.nonce = ajaxRelocationData?.nonce || '';
+
+    fetch(ajaxRelocationData.ajaxurl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(Object.assign({ action: 'calculate_relocation' }, params))
+    })
+    .then(response => response.json())
+    .then(result => {
+        if (result.success) {
+            const fee = result.data.fee;
+            const relocationField = document.getElementById('relocationFee');
+            if (relocationField) {
+                relocationField.value = fee;
+                relocationField.dispatchEvent(new Event('input'));
+            }
+            const output = document.getElementById('relocation-auto-result');
+            if (output) output.textContent = fee;
+        } else {
+            alert(result.data.error || 'Error calculando la relocation fee');
+        }
+    })
+    .catch(() => alert('Error de conexión al calcular la relocation fee'));
+}
+

--- a/app_yacht/modules/calc/php/calculateRelocation.php
+++ b/app_yacht/modules/calc/php/calculateRelocation.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * calculateRelocation.php
+ *
+ * Endpoint de WordPress para calcular automáticamente la "Relocation Fee".
+ * Este script lee parámetros enviados por POST (distancia, horas, consumo,
+ * precio del combustible, tripulación, salarios, tasas de puerto y gastos extra),
+ * calcula un coste aproximado y devuelve la tarifa formateada según la moneda.
+ *
+ * Para su correcto funcionamiento, debes registrar el manejador de la acción
+ * `calculate_relocation` en tu archivo bootstrap.
+ */
+
+// Comprobar nonce de seguridad
+if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'relocation_calculate_nonce' ) ) {
+    wp_send_json_error( [ 'error' => 'Security check failed' ] );
+    return;
+}
+
+// Recoger parámetros opcionales
+$distance        = isset( $_POST['distance'] ) ? floatval( str_replace( ',', '', $_POST['distance'] ) ) : null; // NM
+$hours           = isset( $_POST['hours'] ) ? floatval( str_replace( ',', '', $_POST['hours'] ) ) : null;
+$fuelConsumption = isset( $_POST['fuelConsumption'] ) ? floatval( str_replace( ',', '', $_POST['fuelConsumption'] ) ) : null; // l/h o l/nm
+$fuelPrice       = isset( $_POST['fuelPrice'] ) ? floatval( str_replace( ',', '', $_POST['fuelPrice'] ) ) : null; // €/L
+$crewCount       = isset( $_POST['crewCount'] ) ? floatval( str_replace( ',', '', $_POST['crewCount'] ) ) : null;
+$crewWage        = isset( $_POST['crewWage'] ) ? floatval( str_replace( ',', '', $_POST['crewWage'] ) ) : null; // €/día
+$portFees        = isset( $_POST['portFees'] ) ? floatval( str_replace( ',', '', $_POST['portFees'] ) ) : 0.0;
+$extraCosts      = isset( $_POST['extraCosts'] ) ? floatval( str_replace( ',', '', $_POST['extraCosts'] ) ) : 0.0;
+$currency        = isset( $_POST['currency'] ) ? sanitize_text_field( $_POST['currency'] ) : '€';
+
+// Al menos se debe especificar distancia u horas
+if ( is_null( $distance ) && is_null( $hours ) ) {
+    wp_send_json_error( [ 'error' => 'You must provide either distance or hours to calculate fuel cost.' ] );
+    return;
+}
+
+// Calcular coste de combustible
+$fuelCost = 0.0;
+if ( ! is_null( $fuelPrice ) && ! is_null( $fuelConsumption ) ) {
+    // Si se proporciona distancia y consumo por NM, usar distancia; de lo contrario usar horas
+    if ( ! is_null( $distance ) && $distance > 0 ) {
+        $fuelCost = $distance * $fuelConsumption * $fuelPrice;
+    } elseif ( ! is_null( $hours ) && $hours > 0 ) {
+        $fuelCost = $hours * $fuelConsumption * $fuelPrice;
+    }
+}
+
+// Calcular coste de tripulación (salario diario * días)
+$crewCost = 0.0;
+if ( ! is_null( $crewCount ) && ! is_null( $crewWage ) && $crewCount > 0 ) {
+    // Estimar horas si sólo hay distancia (asumiendo 8 nudos)
+    $estimatedHours = 0.0;
+    if ( ! is_null( $hours ) && $hours > 0 ) {
+        $estimatedHours = $hours;
+    } elseif ( ! is_null( $distance ) && $distance > 0 ) {
+        $estimatedHours = $distance / 8.0;
+    }
+    $estimatedDays = max( 1, ceil( $estimatedHours / 24.0 ) );
+    $crewCost      = $crewCount * $crewWage * $estimatedDays;
+}
+
+// Sumar todos los conceptos
+$total = $fuelCost + $crewCost + $portFees + $extraCosts;
+
+// Formatear resultado
+require_once __DIR__ . '/../../shared/php/currency-functions.php';
+$feeFormatted = formatCurrency( $total, $currency, false );
+
+wp_send_json_success( [ 'fee' => $feeFormatted ] );


### PR DESCRIPTION
## Summary
- add JS mini-calculator for automatic relocation fee
- expose calculate_relocation AJAX endpoint
- hook relocation fee auto UI into calculator template

## Testing
- `npm run lint:js` *(fails: wp-scripts: not found)*
- `composer run-script lint:php`
- `./vendor/bin/phpunit -c app_yacht/phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893515516248329aef5939e72837381