### PR TITLE
Move main menu registration

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -26,6 +26,7 @@ function creativoypunto_setup() {
 				'menu-1' => esc_html__( 'Primary', 'creativoypunto' ),
 			)
 		);
+		register_nav_menu( 'main-menu', esc_html__( 'Main menu', 'creativoypunto' ) );
 
 		
 		add_theme_support(

--- a/inc/menu-creativoypunto.php
+++ b/inc/menu-creativoypunto.php
@@ -78,6 +78,3 @@ class bootstrap_5_menu_creativoypunto extends Walker_Nav_menu {
 }
 
 
-register_nav_menu( 'main-menu', 'Main menu' );
-
-


### PR DESCRIPTION
## Summary
- remove direct main menu registration from Bootstrap walker
- register main menu in `creativoypunto_setup` instead

## Testing
- `php -l inc/menu-creativoypunto.php`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_689601da51a483299eb55c99763d66cc